### PR TITLE
shed few minutes from make testacc by using preexisting FTD

### DIFF
--- a/gen/definitions/device_physical_interface.yaml
+++ b/gen/definitions/device_physical_interface.yaml
@@ -5,12 +5,14 @@ put_create: true
 no_delete: true
 data_source_name_query: true
 doc_category: Devices
+test_tags: [TF_VAR_device_id]
 attributes:
   - tf_name: device_id
     type: String
     reference: true
     description: UUID of the parent device (fmc_device.example.id).
     example: 76d24097-41c4-4558-a4d0-a8c07ac08470
+    test_value: var.device_id
   - model_name: enabled
     type: Bool
     description: Indicates whether to enable the interface.
@@ -170,3 +172,6 @@ attributes:
         type: Bool
         exclude_example: true
         test_value: '"true"'
+
+test_prerequisites: |
+  variable "device_id" { default = null } // tests will set $TF_VAR_device_id

--- a/internal/provider/data_source_fmc_device_physical_interface_test.go
+++ b/internal/provider/data_source_fmc_device_physical_interface_test.go
@@ -19,6 +19,7 @@ package provider
 
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -28,8 +29,10 @@ import (
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSource
 func TestAccDataSourceFmcDevicePhysicalInterface(t *testing.T) {
+	if os.Getenv("TF_VAR_device_id") == "" {
+		t.Skip("skipping test, set environment variable TF_VAR_device_id")
+	}
 	var checks []resource.TestCheckFunc
-	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_physical_interface.test", "device_id", "76d24097-41c4-4558-a4d0-a8c07ac08470"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_physical_interface.test", "mode", "NONE"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_physical_interface.test", "name", "GigabitEthernet0/1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_physical_interface.test", "logical_name", "myinterface-0-1"))
@@ -50,7 +53,7 @@ func TestAccDataSourceFmcDevicePhysicalInterface(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceFmcDevicePhysicalInterfaceConfig(),
+				Config: testAccDataSourceFmcDevicePhysicalInterfacePrerequisitesConfig + testAccDataSourceFmcDevicePhysicalInterfaceConfig(),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},
@@ -60,12 +63,17 @@ func TestAccDataSourceFmcDevicePhysicalInterface(t *testing.T) {
 // End of section. //template:end testAccDataSource
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testPrerequisites
+const testAccDataSourceFmcDevicePhysicalInterfacePrerequisitesConfig = `
+variable "device_id" { default = null } // tests will set $TF_VAR_device_id
+
+`
+
 // End of section. //template:end testPrerequisites
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSourceConfig
 func testAccDataSourceFmcDevicePhysicalInterfaceConfig() string {
 	config := `resource "fmc_device_physical_interface" "test" {` + "\n"
-	config += `	device_id = "76d24097-41c4-4558-a4d0-a8c07ac08470"` + "\n"
+	config += `	device_id = var.device_id` + "\n"
 	config += `	enabled = true` + "\n"
 	config += `	mode = "NONE"` + "\n"
 	config += `	name = "GigabitEthernet0/1"` + "\n"
@@ -91,7 +99,7 @@ func testAccDataSourceFmcDevicePhysicalInterfaceConfig() string {
 	config += `
 		data "fmc_device_physical_interface" "test" {
 			id = fmc_device_physical_interface.test.id
-			device_id = "76d24097-41c4-4558-a4d0-a8c07ac08470"
+			device_id = var.device_id
 		}
 	`
 	return config

--- a/internal/provider/resource_fmc_device_physical_interface_test.go
+++ b/internal/provider/resource_fmc_device_physical_interface_test.go
@@ -29,8 +29,10 @@ import (
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testAcc
 func TestAccFmcDevicePhysicalInterface(t *testing.T) {
+	if os.Getenv("TF_VAR_device_id") == "" {
+		t.Skip("skipping test, set environment variable TF_VAR_device_id")
+	}
 	var checks []resource.TestCheckFunc
-	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_physical_interface.test", "device_id", "76d24097-41c4-4558-a4d0-a8c07ac08470"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_physical_interface.test", "mode", "NONE"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_physical_interface.test", "name", "GigabitEthernet0/1"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_physical_interface.test", "logical_name", "myinterface-0-1"))
@@ -50,11 +52,11 @@ func TestAccFmcDevicePhysicalInterface(t *testing.T) {
 	var steps []resource.TestStep
 	if os.Getenv("SKIP_MINIMUM_TEST") == "" {
 		steps = append(steps, resource.TestStep{
-			Config: testAccFmcDevicePhysicalInterfaceConfig_minimum(),
+			Config: testAccFmcDevicePhysicalInterfacePrerequisitesConfig + testAccFmcDevicePhysicalInterfaceConfig_minimum(),
 		})
 	}
 	steps = append(steps, resource.TestStep{
-		Config: testAccFmcDevicePhysicalInterfaceConfig_all(),
+		Config: testAccFmcDevicePhysicalInterfacePrerequisitesConfig + testAccFmcDevicePhysicalInterfaceConfig_all(),
 		Check:  resource.ComposeTestCheckFunc(checks...),
 	})
 
@@ -68,12 +70,17 @@ func TestAccFmcDevicePhysicalInterface(t *testing.T) {
 // End of section. //template:end testAcc
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testPrerequisites
+const testAccFmcDevicePhysicalInterfacePrerequisitesConfig = `
+variable "device_id" { default = null } // tests will set $TF_VAR_device_id
+
+`
+
 // End of section. //template:end testPrerequisites
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccConfigMinimal
 func testAccFmcDevicePhysicalInterfaceConfig_minimum() string {
 	config := `resource "fmc_device_physical_interface" "test" {` + "\n"
-	config += `	device_id = "76d24097-41c4-4558-a4d0-a8c07ac08470"` + "\n"
+	config += `	device_id = var.device_id` + "\n"
 	config += `	mode = "NONE"` + "\n"
 	config += `	name = "GigabitEthernet0/1"` + "\n"
 	config += `	logical_name = "iface_minimum"` + "\n"
@@ -87,7 +94,7 @@ func testAccFmcDevicePhysicalInterfaceConfig_minimum() string {
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccConfigAll
 func testAccFmcDevicePhysicalInterfaceConfig_all() string {
 	config := `resource "fmc_device_physical_interface" "test" {` + "\n"
-	config += `	device_id = "76d24097-41c4-4558-a4d0-a8c07ac08470"` + "\n"
+	config += `	device_id = var.device_id` + "\n"
 	config += `	enabled = true` + "\n"
 	config += `	mode = "NONE"` + "\n"
 	config += `	name = "GigabitEthernet0/1"` + "\n"


### PR DESCRIPTION
This is a bit ugly for now, but it saves a lot of manual test time.
It uses a device that is always connected to FMC and has a known UUID.
Before this PR, connecting/disconnecting a device used to cost a few (~5) minutes for every test case.

In CI this device is named "preexisting1". In dev work, developer is responsible for standing a fmc_device and setting environment:

```
export TF_VAR_device_id='<fmc_device.test.id>'
```