### PR TITLE
fix: in Create and Update never attempt to modify Known values

### DIFF
--- a/gen/generator.go
+++ b/gen/generator.go
@@ -186,6 +186,11 @@ func SnakeCase(s string) string {
 	return strings.Join(g, "_")
 }
 
+// Templating helper function to fail a template mid-way
+func Errorf(s string, args ...any) (struct{}, error) {
+	return struct{}{}, fmt.Errorf(s, args...)
+}
+
 // Templating helper function to build a SJSON path
 func BuildPath(s []string) string {
 	return strings.Join(s, ".")
@@ -323,6 +328,7 @@ var functions = template.FuncMap{
 	"camelCase":       CamelCase,
 	"snakeCase":       SnakeCase,
 	"sprintf":         fmt.Sprintf,
+	"errorf":          Errorf,
 	"toLower":         strings.ToLower,
 	"path":            BuildPath,
 	"hasId":           HasId,

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -366,9 +366,9 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 
 // End of section. //template:end fromBody
 
-// Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
-func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.Result) {
+func (data *{{camelCase .Name}}) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	{{- range .Attributes}}
 	{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
 	{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
@@ -533,7 +533,7 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 	{{- end}}
 }
 
-// End of section. //template:end updateFromBody
+// End of section. //template:end fromBodyPartial
 
 // Section below is generated&owned by "gen/generator.go". //template:begin isNull
 

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -368,6 +368,10 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
+// fromBodyPartial reads values from a gjson.Result into a tfstate model. It ignores null attributes in order to
+// uncouple the provider from the exact values that the backend API might summon to replace nulls. (Such behavior might
+// easily change across versions of the backend API.) For List/Set/Map attributes, the func only updates the
+// "managed" elements, instead of all elements.
 func (data *{{camelCase .Name}}) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	{{- range .Attributes}}
 	{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -563,7 +563,7 @@ func (data *{{camelCase .Name}}) isNull(ctx context.Context, res gjson.Result) b
 // It excludes UseStateForUnknown+Computed attributes as changes to these during Create/Update would fail Terraform run.
 func (data *{{camelCase .Name}}) computeFromBody(ctx context.Context, res gjson.Result) {
 	{{- range .Attributes}}
-	{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
+	{{- if and .ResourceId (not .Reference)}}
 	{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
 	if value := res.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); value.Exists(){{if not .ResourceId}} && !data.{{toGoName .TfName}}.IsNull(){{end}} {
 		data.{{toGoName .TfName}} = types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
@@ -617,7 +617,7 @@ func (data *{{camelCase .Name}}) computeFromBody(ctx context.Context, res gjson.
 	{{- end}}
 
 		{{- range .Attributes}}
-		{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
+		{{- if and .ResourceId (not .Reference)}}
 		{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
 		if value := r.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); value.Exists() && !data.{{$list}}[i].{{toGoName .TfName}}.IsNull() {
 			data.{{$list}}[i].{{toGoName .TfName}} = types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
@@ -656,7 +656,7 @@ func (data *{{camelCase .Name}}) computeFromBody(ctx context.Context, res gjson.
 			)
 
 			{{- range .Attributes}}
-			{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
+			{{- if and .ResourceId (not .Reference)}}
 			{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
 			if value := cr.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); value.Exists() && !data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}}.IsNull() {
 				data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}} = types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
@@ -695,7 +695,7 @@ func (data *{{camelCase .Name}}) computeFromBody(ctx context.Context, res gjson.
 				)
 
 				{{- range .Attributes}}
-				{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
+				{{- if and .ResourceId (not .Reference)}}
 				{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
 				if value := ccr.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); value.Exists() && !data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{toGoName .TfName}}.IsNull() {
 					data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{toGoName .TfName}} = types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -483,7 +483,7 @@ func (r *{{camelCase .Name}}Resource) Create(ctx context.Context, req resource.C
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))
 		return
 	}
-	plan.updateFromBody(ctx, res)
+	plan.computeFromBody(ctx, res)
 	{{- end}}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
@@ -578,7 +578,7 @@ func (r *{{camelCase .Name}}Resource) Update(ctx context.Context, req resource.U
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))
 		return
 	}
-	plan.updateFromBody(ctx, res)
+	plan.computeFromBody(ctx, res)
 	{{- end}}
 	{{- end}}
 

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -527,7 +527,7 @@ func (r *{{camelCase .Name}}Resource) Read(ctx context.Context, req resource.Rea
 	if state.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
-		state.updateFromBody(ctx, res)
+		state.fromBodyPartial(ctx, res)
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Read finished successfully", state.Id.ValueString()))

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -483,7 +483,7 @@ func (r *{{camelCase .Name}}Resource) Create(ctx context.Context, req resource.C
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))
 		return
 	}
-	plan.computeFromBody(ctx, res)
+	plan.fromBodyUnknowns(ctx, res)
 	{{- end}}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
@@ -578,7 +578,7 @@ func (r *{{camelCase .Name}}Resource) Update(ctx context.Context, req resource.U
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))
 		return
 	}
-	plan.computeFromBody(ctx, res)
+	plan.fromBodyUnknowns(ctx, res)
 	{{- end}}
 	{{- end}}
 

--- a/internal/provider/model_fmc_access_control_policy.go
+++ b/internal/provider/model_fmc_access_control_policy.go
@@ -849,9 +849,9 @@ func (data *AccessControlPolicy) fromBody(ctx context.Context, res gjson.Result)
 
 // End of section. //template:end fromBody
 
-// Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
-func (data *AccessControlPolicy) updateFromBody(ctx context.Context, res gjson.Result) {
+func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
 		data.Name = types.StringValue(value.String())
 	} else {
@@ -1447,9 +1447,9 @@ func (data *AccessControlPolicy) updateFromBody(ctx context.Context, res gjson.R
 	}
 }
 
-// End of section. //template:end updateFromBody
+// End of section. //template:end fromBodyPartial
 
-// adjustFromBody applies a few corrections after an auto-generated fromBody/updateFromBody.
+// adjustFromBody applies a few corrections after an auto-generated fromBody/fromBodyPartial.
 func (data *AccessControlPolicy) adjustFromBody(ctx context.Context, res gjson.Result) {
 	for i := range data.Rules {
 		if data.Rules[i].CategoryName.Equal(types.StringValue("--Undefined--")) {

--- a/internal/provider/model_fmc_access_control_policy.go
+++ b/internal/provider/model_fmc_access_control_policy.go
@@ -1523,16 +1523,8 @@ func (data *AccessControlPolicy) isNull(ctx context.Context, res gjson.Result) b
 
 // End of section. //template:end isNull
 
-// computeFromBody updates the Computed tfstate attributes from a JSON.
-// It excludes Default+Computed attributes as changes to these during Create/Update would fail Terraform run.
-// It excludes UseStateForUnknown+Computed attributes as changes to these during Create/Update would fail Terraform run.
-func (data *AccessControlPolicy) computeFromBody(ctx context.Context, res gjson.Result) {
-	if value := res.Get("defaultAction.id"); value.Exists() {
-		data.DefaultActionId = types.StringValue(value.String())
-	} else {
-		data.DefaultActionId = types.StringNull()
-	}
-}
+// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
+// End of section. //template:end computeFromBody
 
 // NewValidAccessControlPolicy validates the terraform Plan and converts it to a new AccessControlPolicy object.
 // Does not tolerate unknown values (IsUnknown), primarily because tfplan.Get cannot unmarshal unknown lists to []T

--- a/internal/provider/model_fmc_access_control_policy.go
+++ b/internal/provider/model_fmc_access_control_policy.go
@@ -1532,20 +1532,6 @@ func (data *AccessControlPolicy) computeFromBody(ctx context.Context, res gjson.
 	} else {
 		data.DefaultActionId = types.StringNull()
 	}
-	for i := range data.Categories {
-		if value := res.Get(fmt.Sprintf("dummy_categories.%d.id", i)); value.Exists() {
-			data.Categories[i].Id = types.StringValue(value.String())
-		} else {
-			data.Categories[i].Id = types.StringNull()
-		}
-	}
-	for i := range data.Rules {
-		if value := res.Get(fmt.Sprintf("dummy_rules.%d.id", i)); value.Exists() {
-			data.Rules[i].Id = types.StringValue(value.String())
-		} else {
-			data.Rules[i].Id = types.StringNull()
-		}
-	}
 }
 
 // NewValidAccessControlPolicy validates the terraform Plan and converts it to a new AccessControlPolicy object.

--- a/internal/provider/model_fmc_access_control_policy.go
+++ b/internal/provider/model_fmc_access_control_policy.go
@@ -851,6 +851,10 @@ func (data *AccessControlPolicy) fromBody(ctx context.Context, res gjson.Result)
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
+// fromBodyPartial reads values from a gjson.Result into a tfstate model. It ignores null attributes in order to
+// uncouple the provider from the exact values that the backend API might summon to replace nulls. (Such behavior might
+// easily change across versions of the backend API.) For List/Set/Map attributes, the func only updates the
+// "managed" elements, instead of all elements.
 func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
 		data.Name = types.StringValue(value.String())
@@ -1524,6 +1528,39 @@ func (data *AccessControlPolicy) isNull(ctx context.Context, res gjson.Result) b
 // End of section. //template:end isNull
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+
+// fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
+// Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
+func (data *AccessControlPolicy) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.DefaultActionId.IsUnknown() {
+		if value := res.Get("defaultAction.id"); value.Exists() {
+			data.DefaultActionId = types.StringValue(value.String())
+		} else {
+			data.DefaultActionId = types.StringNull()
+		}
+	}
+	for i := range data.Categories {
+		r := res.Get(fmt.Sprintf("dummy_categories.%d", i))
+		if data.Categories[i].Id.IsUnknown() {
+			if value := r.Get("id"); value.Exists() {
+				data.Categories[i].Id = types.StringValue(value.String())
+			} else {
+				data.Categories[i].Id = types.StringNull()
+			}
+		}
+	}
+	for i := range data.Rules {
+		r := res.Get(fmt.Sprintf("dummy_rules.%d", i))
+		if data.Rules[i].Id.IsUnknown() {
+			if value := r.Get("id"); value.Exists() {
+				data.Rules[i].Id = types.StringValue(value.String())
+			} else {
+				data.Rules[i].Id = types.StringNull()
+			}
+		}
+	}
+}
+
 // End of section. //template:end fromBodyUnknowns
 
 // NewValidAccessControlPolicy validates the terraform Plan and converts it to a new AccessControlPolicy object.

--- a/internal/provider/model_fmc_access_control_policy.go
+++ b/internal/provider/model_fmc_access_control_policy.go
@@ -1523,8 +1523,8 @@ func (data *AccessControlPolicy) isNull(ctx context.Context, res gjson.Result) b
 
 // End of section. //template:end isNull
 
-// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
-// End of section. //template:end computeFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+// End of section. //template:end fromBodyUnknowns
 
 // NewValidAccessControlPolicy validates the terraform Plan and converts it to a new AccessControlPolicy object.
 // Does not tolerate unknown values (IsUnknown), primarily because tfplan.Get cannot unmarshal unknown lists to []T

--- a/internal/provider/model_fmc_device.go
+++ b/internal/provider/model_fmc_device.go
@@ -131,6 +131,10 @@ func (data *Device) fromBody(ctx context.Context, res gjson.Result) {
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
+// fromBodyPartial reads values from a gjson.Result into a tfstate model. It ignores null attributes in order to
+// uncouple the provider from the exact values that the backend API might summon to replace nulls. (Such behavior might
+// easily change across versions of the backend API.) For List/Set/Map attributes, the func only updates the
+// "managed" elements, instead of all elements.
 func (data *Device) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
 		data.Name = types.StringValue(value.String())
@@ -251,4 +255,10 @@ func (data *Device) isNull(ctx context.Context, res gjson.Result) bool {
 // End of section. //template:end isNull
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+
+// fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
+// Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
+func (data *Device) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+}
+
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_device.go
+++ b/internal/provider/model_fmc_device.go
@@ -250,5 +250,5 @@ func (data *Device) isNull(ctx context.Context, res gjson.Result) bool {
 
 // End of section. //template:end isNull
 
-// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
-// End of section. //template:end computeFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+// End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_device.go
+++ b/internal/provider/model_fmc_device.go
@@ -249,3 +249,6 @@ func (data *Device) isNull(ctx context.Context, res gjson.Result) bool {
 }
 
 // End of section. //template:end isNull
+
+// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
+// End of section. //template:end computeFromBody

--- a/internal/provider/model_fmc_device.go
+++ b/internal/provider/model_fmc_device.go
@@ -129,9 +129,9 @@ func (data *Device) fromBody(ctx context.Context, res gjson.Result) {
 
 // End of section. //template:end fromBody
 
-// Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
-func (data *Device) updateFromBody(ctx context.Context, res gjson.Result) {
+func (data *Device) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
 		data.Name = types.StringValue(value.String())
 	} else {
@@ -154,7 +154,7 @@ func (data *Device) updateFromBody(ctx context.Context, res gjson.Result) {
 	}
 }
 
-// End of section. //template:end updateFromBody
+// End of section. //template:end fromBodyPartial
 
 func (data *Device) fromPolicyBody(ctx context.Context, res gjson.Result) {
 	query := fmt.Sprintf(`items.#(targets.#(id=="%s"))#.policy`, data.Id.ValueString())

--- a/internal/provider/model_fmc_device_ipv4_static_route.go
+++ b/internal/provider/model_fmc_device_ipv4_static_route.go
@@ -144,9 +144,9 @@ func (data *DeviceIPv4StaticRoute) fromBody(ctx context.Context, res gjson.Resul
 
 // End of section. //template:end fromBody
 
-// Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
-func (data *DeviceIPv4StaticRoute) updateFromBody(ctx context.Context, res gjson.Result) {
+func (data *DeviceIPv4StaticRoute) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("interfaceName"); value.Exists() && !data.InterfaceLogicalName.IsNull() {
 		data.InterfaceLogicalName = types.StringValue(value.String())
 	} else {
@@ -202,7 +202,7 @@ func (data *DeviceIPv4StaticRoute) updateFromBody(ctx context.Context, res gjson
 	}
 }
 
-// End of section. //template:end updateFromBody
+// End of section. //template:end fromBodyPartial
 
 // Section below is generated&owned by "gen/generator.go". //template:begin isNull
 

--- a/internal/provider/model_fmc_device_ipv4_static_route.go
+++ b/internal/provider/model_fmc_device_ipv4_static_route.go
@@ -146,6 +146,10 @@ func (data *DeviceIPv4StaticRoute) fromBody(ctx context.Context, res gjson.Resul
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
+// fromBodyPartial reads values from a gjson.Result into a tfstate model. It ignores null attributes in order to
+// uncouple the provider from the exact values that the backend API might summon to replace nulls. (Such behavior might
+// easily change across versions of the backend API.) For List/Set/Map attributes, the func only updates the
+// "managed" elements, instead of all elements.
 func (data *DeviceIPv4StaticRoute) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("interfaceName"); value.Exists() && !data.InterfaceLogicalName.IsNull() {
 		data.InterfaceLogicalName = types.StringValue(value.String())
@@ -237,4 +241,10 @@ func (data *DeviceIPv4StaticRoute) isNull(ctx context.Context, res gjson.Result)
 // End of section. //template:end isNull
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+
+// fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
+// Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
+func (data *DeviceIPv4StaticRoute) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+}
+
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_device_ipv4_static_route.go
+++ b/internal/provider/model_fmc_device_ipv4_static_route.go
@@ -236,5 +236,5 @@ func (data *DeviceIPv4StaticRoute) isNull(ctx context.Context, res gjson.Result)
 
 // End of section. //template:end isNull
 
-// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
-// End of section. //template:end computeFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+// End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_device_ipv4_static_route.go
+++ b/internal/provider/model_fmc_device_ipv4_static_route.go
@@ -235,3 +235,6 @@ func (data *DeviceIPv4StaticRoute) isNull(ctx context.Context, res gjson.Result)
 }
 
 // End of section. //template:end isNull
+
+// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
+// End of section. //template:end computeFromBody

--- a/internal/provider/model_fmc_device_ipv6_static_route.go
+++ b/internal/provider/model_fmc_device_ipv6_static_route.go
@@ -146,6 +146,10 @@ func (data *DeviceIPv6StaticRoute) fromBody(ctx context.Context, res gjson.Resul
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
+// fromBodyPartial reads values from a gjson.Result into a tfstate model. It ignores null attributes in order to
+// uncouple the provider from the exact values that the backend API might summon to replace nulls. (Such behavior might
+// easily change across versions of the backend API.) For List/Set/Map attributes, the func only updates the
+// "managed" elements, instead of all elements.
 func (data *DeviceIPv6StaticRoute) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("interfaceName"); value.Exists() && !data.InterfaceLogicalName.IsNull() {
 		data.InterfaceLogicalName = types.StringValue(value.String())
@@ -237,4 +241,10 @@ func (data *DeviceIPv6StaticRoute) isNull(ctx context.Context, res gjson.Result)
 // End of section. //template:end isNull
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+
+// fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
+// Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
+func (data *DeviceIPv6StaticRoute) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+}
+
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_device_ipv6_static_route.go
+++ b/internal/provider/model_fmc_device_ipv6_static_route.go
@@ -236,5 +236,5 @@ func (data *DeviceIPv6StaticRoute) isNull(ctx context.Context, res gjson.Result)
 
 // End of section. //template:end isNull
 
-// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
-// End of section. //template:end computeFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+// End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_device_ipv6_static_route.go
+++ b/internal/provider/model_fmc_device_ipv6_static_route.go
@@ -235,3 +235,6 @@ func (data *DeviceIPv6StaticRoute) isNull(ctx context.Context, res gjson.Result)
 }
 
 // End of section. //template:end isNull
+
+// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
+// End of section. //template:end computeFromBody

--- a/internal/provider/model_fmc_device_ipv6_static_route.go
+++ b/internal/provider/model_fmc_device_ipv6_static_route.go
@@ -144,9 +144,9 @@ func (data *DeviceIPv6StaticRoute) fromBody(ctx context.Context, res gjson.Resul
 
 // End of section. //template:end fromBody
 
-// Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
-func (data *DeviceIPv6StaticRoute) updateFromBody(ctx context.Context, res gjson.Result) {
+func (data *DeviceIPv6StaticRoute) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("interfaceName"); value.Exists() && !data.InterfaceLogicalName.IsNull() {
 		data.InterfaceLogicalName = types.StringValue(value.String())
 	} else {
@@ -202,7 +202,7 @@ func (data *DeviceIPv6StaticRoute) updateFromBody(ctx context.Context, res gjson
 	}
 }
 
-// End of section. //template:end updateFromBody
+// End of section. //template:end fromBodyPartial
 
 // Section below is generated&owned by "gen/generator.go". //template:begin isNull
 

--- a/internal/provider/model_fmc_device_physical_interface.go
+++ b/internal/provider/model_fmc_device_physical_interface.go
@@ -497,5 +497,5 @@ func (data *DevicePhysicalInterface) isNull(ctx context.Context, res gjson.Resul
 
 // End of section. //template:end isNull
 
-// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
-// End of section. //template:end computeFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+// End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_device_physical_interface.go
+++ b/internal/provider/model_fmc_device_physical_interface.go
@@ -286,9 +286,9 @@ func (data *DevicePhysicalInterface) fromBody(ctx context.Context, res gjson.Res
 
 // End of section. //template:end fromBody
 
-// Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
-func (data *DevicePhysicalInterface) updateFromBody(ctx context.Context, res gjson.Result) {
+func (data *DevicePhysicalInterface) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("enabled"); value.Exists() && !data.Enabled.IsNull() {
 		data.Enabled = types.BoolValue(value.Bool())
 	} else if data.Enabled.ValueBool() != true {
@@ -424,7 +424,7 @@ func (data *DevicePhysicalInterface) updateFromBody(ctx context.Context, res gjs
 	}
 }
 
-// End of section. //template:end updateFromBody
+// End of section. //template:end fromBodyPartial
 
 // Section below is generated&owned by "gen/generator.go". //template:begin isNull
 

--- a/internal/provider/model_fmc_device_physical_interface.go
+++ b/internal/provider/model_fmc_device_physical_interface.go
@@ -288,6 +288,10 @@ func (data *DevicePhysicalInterface) fromBody(ctx context.Context, res gjson.Res
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
+// fromBodyPartial reads values from a gjson.Result into a tfstate model. It ignores null attributes in order to
+// uncouple the provider from the exact values that the backend API might summon to replace nulls. (Such behavior might
+// easily change across versions of the backend API.) For List/Set/Map attributes, the func only updates the
+// "managed" elements, instead of all elements.
 func (data *DevicePhysicalInterface) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("enabled"); value.Exists() && !data.Enabled.IsNull() {
 		data.Enabled = types.BoolValue(value.Bool())
@@ -498,4 +502,10 @@ func (data *DevicePhysicalInterface) isNull(ctx context.Context, res gjson.Resul
 // End of section. //template:end isNull
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+
+// fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
+// Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
+func (data *DevicePhysicalInterface) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+}
+
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_device_physical_interface.go
+++ b/internal/provider/model_fmc_device_physical_interface.go
@@ -496,3 +496,6 @@ func (data *DevicePhysicalInterface) isNull(ctx context.Context, res gjson.Resul
 }
 
 // End of section. //template:end isNull
+
+// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
+// End of section. //template:end computeFromBody

--- a/internal/provider/model_fmc_device_subinterface.go
+++ b/internal/provider/model_fmc_device_subinterface.go
@@ -300,6 +300,10 @@ func (data *DeviceSubinterface) fromBody(ctx context.Context, res gjson.Result) 
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
+// fromBodyPartial reads values from a gjson.Result into a tfstate model. It ignores null attributes in order to
+// uncouple the provider from the exact values that the backend API might summon to replace nulls. (Such behavior might
+// easily change across versions of the backend API.) For List/Set/Map attributes, the func only updates the
+// "managed" elements, instead of all elements.
 func (data *DeviceSubinterface) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("enabled"); value.Exists() && !data.Enabled.IsNull() {
 		data.Enabled = types.BoolValue(value.Bool())
@@ -521,4 +525,17 @@ func (data *DeviceSubinterface) isNull(ctx context.Context, res gjson.Result) bo
 // End of section. //template:end isNull
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+
+// fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
+// Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
+func (data *DeviceSubinterface) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.InterfaceName.IsUnknown() {
+		if value := res.Get("name"); value.Exists() {
+			data.InterfaceName = types.StringValue(value.String())
+		} else {
+			data.InterfaceName = types.StringNull()
+		}
+	}
+}
+
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_device_subinterface.go
+++ b/internal/provider/model_fmc_device_subinterface.go
@@ -519,3 +519,6 @@ func (data *DeviceSubinterface) isNull(ctx context.Context, res gjson.Result) bo
 }
 
 // End of section. //template:end isNull
+
+// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
+// End of section. //template:end computeFromBody

--- a/internal/provider/model_fmc_device_subinterface.go
+++ b/internal/provider/model_fmc_device_subinterface.go
@@ -520,5 +520,5 @@ func (data *DeviceSubinterface) isNull(ctx context.Context, res gjson.Result) bo
 
 // End of section. //template:end isNull
 
-// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
-// End of section. //template:end computeFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+// End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_device_subinterface.go
+++ b/internal/provider/model_fmc_device_subinterface.go
@@ -298,9 +298,9 @@ func (data *DeviceSubinterface) fromBody(ctx context.Context, res gjson.Result) 
 
 // End of section. //template:end fromBody
 
-// Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
-func (data *DeviceSubinterface) updateFromBody(ctx context.Context, res gjson.Result) {
+func (data *DeviceSubinterface) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("enabled"); value.Exists() && !data.Enabled.IsNull() {
 		data.Enabled = types.BoolValue(value.Bool())
 	} else if data.Enabled.ValueBool() != true {
@@ -441,7 +441,7 @@ func (data *DeviceSubinterface) updateFromBody(ctx context.Context, res gjson.Re
 	}
 }
 
-// End of section. //template:end updateFromBody
+// End of section. //template:end fromBodyPartial
 
 // Section below is generated&owned by "gen/generator.go". //template:begin isNull
 

--- a/internal/provider/model_fmc_host.go
+++ b/internal/provider/model_fmc_host.go
@@ -164,5 +164,5 @@ func (data *Host) isNull(ctx context.Context, res gjson.Result) bool {
 
 // End of section. //template:end isNull
 
-// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
-// End of section. //template:end computeFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+// End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_host.go
+++ b/internal/provider/model_fmc_host.go
@@ -111,6 +111,10 @@ func (data *Host) fromBody(ctx context.Context, res gjson.Result) {
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
+// fromBodyPartial reads values from a gjson.Result into a tfstate model. It ignores null attributes in order to
+// uncouple the provider from the exact values that the backend API might summon to replace nulls. (Such behavior might
+// easily change across versions of the backend API.) For List/Set/Map attributes, the func only updates the
+// "managed" elements, instead of all elements.
 func (data *Host) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
 		data.Name = types.StringValue(value.String())
@@ -165,4 +169,10 @@ func (data *Host) isNull(ctx context.Context, res gjson.Result) bool {
 // End of section. //template:end isNull
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+
+// fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
+// Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
+func (data *Host) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+}
+
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_host.go
+++ b/internal/provider/model_fmc_host.go
@@ -109,9 +109,9 @@ func (data *Host) fromBody(ctx context.Context, res gjson.Result) {
 
 // End of section. //template:end fromBody
 
-// Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
-func (data *Host) updateFromBody(ctx context.Context, res gjson.Result) {
+func (data *Host) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
 		data.Name = types.StringValue(value.String())
 	} else {
@@ -139,7 +139,7 @@ func (data *Host) updateFromBody(ctx context.Context, res gjson.Result) {
 	}
 }
 
-// End of section. //template:end updateFromBody
+// End of section. //template:end fromBodyPartial
 
 // Section below is generated&owned by "gen/generator.go". //template:begin isNull
 

--- a/internal/provider/model_fmc_host.go
+++ b/internal/provider/model_fmc_host.go
@@ -163,3 +163,6 @@ func (data *Host) isNull(ctx context.Context, res gjson.Result) bool {
 }
 
 // End of section. //template:end isNull
+
+// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
+// End of section. //template:end computeFromBody

--- a/internal/provider/model_fmc_icmpv4_object.go
+++ b/internal/provider/model_fmc_icmpv4_object.go
@@ -164,5 +164,5 @@ func (data *ICMPv4Object) isNull(ctx context.Context, res gjson.Result) bool {
 
 // End of section. //template:end isNull
 
-// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
-// End of section. //template:end computeFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+// End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_icmpv4_object.go
+++ b/internal/provider/model_fmc_icmpv4_object.go
@@ -163,3 +163,6 @@ func (data *ICMPv4Object) isNull(ctx context.Context, res gjson.Result) bool {
 }
 
 // End of section. //template:end isNull
+
+// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
+// End of section. //template:end computeFromBody

--- a/internal/provider/model_fmc_icmpv4_object.go
+++ b/internal/provider/model_fmc_icmpv4_object.go
@@ -111,6 +111,10 @@ func (data *ICMPv4Object) fromBody(ctx context.Context, res gjson.Result) {
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
+// fromBodyPartial reads values from a gjson.Result into a tfstate model. It ignores null attributes in order to
+// uncouple the provider from the exact values that the backend API might summon to replace nulls. (Such behavior might
+// easily change across versions of the backend API.) For List/Set/Map attributes, the func only updates the
+// "managed" elements, instead of all elements.
 func (data *ICMPv4Object) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("icmpType"); value.Exists() && !data.IcmpType.IsNull() {
 		data.IcmpType = types.Int64Value(value.Int())
@@ -165,4 +169,10 @@ func (data *ICMPv4Object) isNull(ctx context.Context, res gjson.Result) bool {
 // End of section. //template:end isNull
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+
+// fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
+// Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
+func (data *ICMPv4Object) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+}
+
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_icmpv4_object.go
+++ b/internal/provider/model_fmc_icmpv4_object.go
@@ -109,9 +109,9 @@ func (data *ICMPv4Object) fromBody(ctx context.Context, res gjson.Result) {
 
 // End of section. //template:end fromBody
 
-// Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
-func (data *ICMPv4Object) updateFromBody(ctx context.Context, res gjson.Result) {
+func (data *ICMPv4Object) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("icmpType"); value.Exists() && !data.IcmpType.IsNull() {
 		data.IcmpType = types.Int64Value(value.Int())
 	} else {
@@ -139,7 +139,7 @@ func (data *ICMPv4Object) updateFromBody(ctx context.Context, res gjson.Result) 
 	}
 }
 
-// End of section. //template:end updateFromBody
+// End of section. //template:end fromBodyPartial
 
 // Section below is generated&owned by "gen/generator.go". //template:begin isNull
 

--- a/internal/provider/model_fmc_network.go
+++ b/internal/provider/model_fmc_network.go
@@ -109,9 +109,9 @@ func (data *Network) fromBody(ctx context.Context, res gjson.Result) {
 
 // End of section. //template:end fromBody
 
-// Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
-func (data *Network) updateFromBody(ctx context.Context, res gjson.Result) {
+func (data *Network) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
 		data.Name = types.StringValue(value.String())
 	} else {
@@ -139,7 +139,7 @@ func (data *Network) updateFromBody(ctx context.Context, res gjson.Result) {
 	}
 }
 
-// End of section. //template:end updateFromBody
+// End of section. //template:end fromBodyPartial
 
 // Section below is generated&owned by "gen/generator.go". //template:begin isNull
 

--- a/internal/provider/model_fmc_network.go
+++ b/internal/provider/model_fmc_network.go
@@ -163,3 +163,6 @@ func (data *Network) isNull(ctx context.Context, res gjson.Result) bool {
 }
 
 // End of section. //template:end isNull
+
+// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
+// End of section. //template:end computeFromBody

--- a/internal/provider/model_fmc_network.go
+++ b/internal/provider/model_fmc_network.go
@@ -111,6 +111,10 @@ func (data *Network) fromBody(ctx context.Context, res gjson.Result) {
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
+// fromBodyPartial reads values from a gjson.Result into a tfstate model. It ignores null attributes in order to
+// uncouple the provider from the exact values that the backend API might summon to replace nulls. (Such behavior might
+// easily change across versions of the backend API.) For List/Set/Map attributes, the func only updates the
+// "managed" elements, instead of all elements.
 func (data *Network) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
 		data.Name = types.StringValue(value.String())
@@ -165,4 +169,10 @@ func (data *Network) isNull(ctx context.Context, res gjson.Result) bool {
 // End of section. //template:end isNull
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+
+// fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
+// Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
+func (data *Network) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+}
+
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_network.go
+++ b/internal/provider/model_fmc_network.go
@@ -164,5 +164,5 @@ func (data *Network) isNull(ctx context.Context, res gjson.Result) bool {
 
 // End of section. //template:end isNull
 
-// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
-// End of section. //template:end computeFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+// End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_security_zone.go
+++ b/internal/provider/model_fmc_security_zone.go
@@ -84,6 +84,10 @@ func (data *SecurityZone) fromBody(ctx context.Context, res gjson.Result) {
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
+// fromBodyPartial reads values from a gjson.Result into a tfstate model. It ignores null attributes in order to
+// uncouple the provider from the exact values that the backend API might summon to replace nulls. (Such behavior might
+// easily change across versions of the backend API.) For List/Set/Map attributes, the func only updates the
+// "managed" elements, instead of all elements.
 func (data *SecurityZone) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
 		data.Name = types.StringValue(value.String())
@@ -114,4 +118,10 @@ func (data *SecurityZone) isNull(ctx context.Context, res gjson.Result) bool {
 // End of section. //template:end isNull
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+
+// fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
+// Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
+func (data *SecurityZone) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+}
+
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_security_zone.go
+++ b/internal/provider/model_fmc_security_zone.go
@@ -113,5 +113,5 @@ func (data *SecurityZone) isNull(ctx context.Context, res gjson.Result) bool {
 
 // End of section. //template:end isNull
 
-// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
-// End of section. //template:end computeFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
+// End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_security_zone.go
+++ b/internal/provider/model_fmc_security_zone.go
@@ -82,9 +82,9 @@ func (data *SecurityZone) fromBody(ctx context.Context, res gjson.Result) {
 
 // End of section. //template:end fromBody
 
-// Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
+// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
-func (data *SecurityZone) updateFromBody(ctx context.Context, res gjson.Result) {
+func (data *SecurityZone) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
 		data.Name = types.StringValue(value.String())
 	} else {
@@ -97,7 +97,7 @@ func (data *SecurityZone) updateFromBody(ctx context.Context, res gjson.Result) 
 	}
 }
 
-// End of section. //template:end updateFromBody
+// End of section. //template:end fromBodyPartial
 
 // Section below is generated&owned by "gen/generator.go". //template:begin isNull
 

--- a/internal/provider/model_fmc_security_zone.go
+++ b/internal/provider/model_fmc_security_zone.go
@@ -112,3 +112,6 @@ func (data *SecurityZone) isNull(ctx context.Context, res gjson.Result) bool {
 }
 
 // End of section. //template:end isNull
+
+// Section below is generated&owned by "gen/generator.go". //template:begin computeFromBody
+// End of section. //template:end computeFromBody

--- a/internal/provider/resource_fmc_access_control_policy.go
+++ b/internal/provider/resource_fmc_access_control_policy.go
@@ -516,7 +516,7 @@ func (r *AccessControlPolicyResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
-	plan.computeFromBody(ctx, read)
+	plan.fromBodyUnknowns(ctx, read)
 
 	err = r.createCatsAt(ctx, plan, bodyCats, 0, &plan, reqMods...)
 	if err != nil {
@@ -658,7 +658,7 @@ func (r *AccessControlPolicyResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
-	plan.computeFromBody(ctx, res)
+	plan.fromBodyUnknowns(ctx, res)
 
 	keptCats, keptRules := r.countKept(ctx, state, plan)
 

--- a/internal/provider/resource_fmc_access_control_policy.go
+++ b/internal/provider/resource_fmc_access_control_policy.go
@@ -610,7 +610,7 @@ func (r *AccessControlPolicyResource) Read(ctx context.Context, req resource.Rea
 	if state.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
-		state.updateFromBody(ctx, res)
+		state.fromBodyPartial(ctx, res)
 	}
 	state.adjustFromBody(ctx, res)
 

--- a/internal/provider/resource_fmc_device.go
+++ b/internal/provider/resource_fmc_device.go
@@ -280,7 +280,7 @@ func (r *DeviceResource) Read(ctx context.Context, req resource.ReadRequest, res
 		state.fromBody(ctx, res)
 		state.fromPolicyBody(ctx, policies)
 	} else {
-		state.updateFromBody(ctx, res)
+		state.fromBodyPartial(ctx, res)
 		state.updateFromPolicyBody(ctx, policies)
 		tflog.Debug(ctx, fmt.Sprintf("nat policy assignment after update: %s", state.NatPolicyId))
 	}

--- a/internal/provider/resource_fmc_device_ipv4_static_route.go
+++ b/internal/provider/resource_fmc_device_ipv4_static_route.go
@@ -213,7 +213,7 @@ func (r *DeviceIPv4StaticRouteResource) Read(ctx context.Context, req resource.R
 	if state.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
-		state.updateFromBody(ctx, res)
+		state.fromBodyPartial(ctx, res)
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Read finished successfully", state.Id.ValueString()))

--- a/internal/provider/resource_fmc_device_ipv6_static_route.go
+++ b/internal/provider/resource_fmc_device_ipv6_static_route.go
@@ -213,7 +213,7 @@ func (r *DeviceIPv6StaticRouteResource) Read(ctx context.Context, req resource.R
 	if state.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
-		state.updateFromBody(ctx, res)
+		state.fromBodyPartial(ctx, res)
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Read finished successfully", state.Id.ValueString()))

--- a/internal/provider/resource_fmc_device_physical_interface.go
+++ b/internal/provider/resource_fmc_device_physical_interface.go
@@ -310,7 +310,7 @@ func (r *DevicePhysicalInterfaceResource) Read(ctx context.Context, req resource
 	if state.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
-		state.updateFromBody(ctx, res)
+		state.fromBodyPartial(ctx, res)
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Read finished successfully", state.Id.ValueString()))

--- a/internal/provider/resource_fmc_device_subinterface.go
+++ b/internal/provider/resource_fmc_device_subinterface.go
@@ -273,7 +273,7 @@ func (r *DeviceSubinterfaceResource) Create(ctx context.Context, req resource.Cr
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))
 		return
 	}
-	plan.computeFromBody(ctx, res)
+	plan.fromBodyUnknowns(ctx, res)
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -362,7 +362,7 @@ func (r *DeviceSubinterfaceResource) Update(ctx context.Context, req resource.Up
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))
 		return
 	}
-	plan.computeFromBody(ctx, res)
+	plan.fromBodyUnknowns(ctx, res)
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Update finished successfully", plan.Id.ValueString()))
 

--- a/internal/provider/resource_fmc_device_subinterface.go
+++ b/internal/provider/resource_fmc_device_subinterface.go
@@ -314,7 +314,7 @@ func (r *DeviceSubinterfaceResource) Read(ctx context.Context, req resource.Read
 	if state.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
-		state.updateFromBody(ctx, res)
+		state.fromBodyPartial(ctx, res)
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Read finished successfully", state.Id.ValueString()))

--- a/internal/provider/resource_fmc_device_subinterface.go
+++ b/internal/provider/resource_fmc_device_subinterface.go
@@ -273,7 +273,7 @@ func (r *DeviceSubinterfaceResource) Create(ctx context.Context, req resource.Cr
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))
 		return
 	}
-	plan.updateFromBody(ctx, res)
+	plan.computeFromBody(ctx, res)
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -362,7 +362,7 @@ func (r *DeviceSubinterfaceResource) Update(ctx context.Context, req resource.Up
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))
 		return
 	}
-	plan.updateFromBody(ctx, res)
+	plan.computeFromBody(ctx, res)
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Update finished successfully", plan.Id.ValueString()))
 

--- a/internal/provider/resource_fmc_host.go
+++ b/internal/provider/resource_fmc_host.go
@@ -187,7 +187,7 @@ func (r *HostResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	if state.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
-		state.updateFromBody(ctx, res)
+		state.fromBodyPartial(ctx, res)
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Read finished successfully", state.Id.ValueString()))

--- a/internal/provider/resource_fmc_icmpv4_object.go
+++ b/internal/provider/resource_fmc_icmpv4_object.go
@@ -189,7 +189,7 @@ func (r *ICMPv4ObjectResource) Read(ctx context.Context, req resource.ReadReques
 	if state.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
-		state.updateFromBody(ctx, res)
+		state.fromBodyPartial(ctx, res)
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Read finished successfully", state.Id.ValueString()))

--- a/internal/provider/resource_fmc_network.go
+++ b/internal/provider/resource_fmc_network.go
@@ -187,7 +187,7 @@ func (r *NetworkResource) Read(ctx context.Context, req resource.ReadRequest, re
 	if state.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
-		state.updateFromBody(ctx, res)
+		state.fromBodyPartial(ctx, res)
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Read finished successfully", state.Id.ValueString()))

--- a/internal/provider/resource_fmc_security_zone.go
+++ b/internal/provider/resource_fmc_security_zone.go
@@ -177,7 +177,7 @@ func (r *SecurityZoneResource) Read(ctx context.Context, req resource.ReadReques
 	if state.isNull(ctx, res) {
 		state.fromBody(ctx, res)
 	} else {
-		state.updateFromBody(ctx, res)
+		state.fromBodyPartial(ctx, res)
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Read finished successfully", state.Id.ValueString()))


### PR DESCRIPTION
Fix of a slight bug exposure. The existing `updateFromBody` might sometimes read a Known state value during Create or Update (only if the config item is IsNull). In this situation terraform complains loudly that this is "always a bug in provider", because we break the contract of Create or Update.

After this change, Create or Update only read unknown values.

Also, rename `updateFromBody` to `fromBodyPartial`, because it is no longer called from within Update. Keeping the old name would be probably miselading.

This is not specific to FMC in any way, this probably applies to all instances of `updateFromBody` idea.

(BTW: I've got a further idea, how to get rid of isNull and replace it with something lighter)