### PR TITLE
fix template: delete non-existing elements

### DIFF
--- a/internal/provider/model_fmc_access_control_policy.go
+++ b/internal/provider/model_fmc_access_control_policy.go
@@ -982,7 +982,7 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 		} else if data.Rules[i].Enabled.ValueBool() != true {
 			data.Rules[i].Enabled = types.BoolNull()
 		}
-		for ci := range data.Rules[i].SourceNetworkLiterals {
+		for ci := 0; ci < len(data.Rules[i].SourceNetworkLiterals); ci++ {
 			keys := [...]string{"value"}
 			keyValues := [...]string{data.Rules[i].SourceNetworkLiterals[ci].Value.ValueString()}
 
@@ -1004,13 +1004,23 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 					return true
 				},
 			)
+			if !cr.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].SourceNetworkLiterals[%d] = %+v",
+					ci,
+					data.Rules[i].SourceNetworkLiterals[ci],
+				))
+				data.Rules[i].SourceNetworkLiterals = slices.Delete(data.Rules[i].SourceNetworkLiterals, ci, ci+1)
+				ci--
+
+				continue
+			}
 			if value := cr.Get("value"); value.Exists() && !data.Rules[i].SourceNetworkLiterals[ci].Value.IsNull() {
 				data.Rules[i].SourceNetworkLiterals[ci].Value = types.StringValue(value.String())
 			} else {
 				data.Rules[i].SourceNetworkLiterals[ci].Value = types.StringNull()
 			}
 		}
-		for ci := range data.Rules[i].DestinationNetworkLiterals {
+		for ci := 0; ci < len(data.Rules[i].DestinationNetworkLiterals); ci++ {
 			keys := [...]string{"value"}
 			keyValues := [...]string{data.Rules[i].DestinationNetworkLiterals[ci].Value.ValueString()}
 
@@ -1032,13 +1042,23 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 					return true
 				},
 			)
+			if !cr.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].DestinationNetworkLiterals[%d] = %+v",
+					ci,
+					data.Rules[i].DestinationNetworkLiterals[ci],
+				))
+				data.Rules[i].DestinationNetworkLiterals = slices.Delete(data.Rules[i].DestinationNetworkLiterals, ci, ci+1)
+				ci--
+
+				continue
+			}
 			if value := cr.Get("value"); value.Exists() && !data.Rules[i].DestinationNetworkLiterals[ci].Value.IsNull() {
 				data.Rules[i].DestinationNetworkLiterals[ci].Value = types.StringValue(value.String())
 			} else {
 				data.Rules[i].DestinationNetworkLiterals[ci].Value = types.StringNull()
 			}
 		}
-		for ci := range data.Rules[i].SourceNetworkObjects {
+		for ci := 0; ci < len(data.Rules[i].SourceNetworkObjects); ci++ {
 			keys := [...]string{"id"}
 			keyValues := [...]string{data.Rules[i].SourceNetworkObjects[ci].Id.ValueString()}
 
@@ -1060,6 +1080,16 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 					return true
 				},
 			)
+			if !cr.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].SourceNetworkObjects[%d] = %+v",
+					ci,
+					data.Rules[i].SourceNetworkObjects[ci],
+				))
+				data.Rules[i].SourceNetworkObjects = slices.Delete(data.Rules[i].SourceNetworkObjects, ci, ci+1)
+				ci--
+
+				continue
+			}
 			if value := cr.Get("id"); value.Exists() && !data.Rules[i].SourceNetworkObjects[ci].Id.IsNull() {
 				data.Rules[i].SourceNetworkObjects[ci].Id = types.StringValue(value.String())
 			} else {
@@ -1071,7 +1101,7 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 				data.Rules[i].SourceNetworkObjects[ci].Type = types.StringNull()
 			}
 		}
-		for ci := range data.Rules[i].DestinationNetworkObjects {
+		for ci := 0; ci < len(data.Rules[i].DestinationNetworkObjects); ci++ {
 			keys := [...]string{"id"}
 			keyValues := [...]string{data.Rules[i].DestinationNetworkObjects[ci].Id.ValueString()}
 
@@ -1093,6 +1123,16 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 					return true
 				},
 			)
+			if !cr.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].DestinationNetworkObjects[%d] = %+v",
+					ci,
+					data.Rules[i].DestinationNetworkObjects[ci],
+				))
+				data.Rules[i].DestinationNetworkObjects = slices.Delete(data.Rules[i].DestinationNetworkObjects, ci, ci+1)
+				ci--
+
+				continue
+			}
 			if value := cr.Get("id"); value.Exists() && !data.Rules[i].DestinationNetworkObjects[ci].Id.IsNull() {
 				data.Rules[i].DestinationNetworkObjects[ci].Id = types.StringValue(value.String())
 			} else {
@@ -1104,7 +1144,7 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 				data.Rules[i].DestinationNetworkObjects[ci].Type = types.StringNull()
 			}
 		}
-		for ci := range data.Rules[i].SourceDynamicObjects {
+		for ci := 0; ci < len(data.Rules[i].SourceDynamicObjects); ci++ {
 			keys := [...]string{"id"}
 			keyValues := [...]string{data.Rules[i].SourceDynamicObjects[ci].Id.ValueString()}
 
@@ -1126,13 +1166,23 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 					return true
 				},
 			)
+			if !cr.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].SourceDynamicObjects[%d] = %+v",
+					ci,
+					data.Rules[i].SourceDynamicObjects[ci],
+				))
+				data.Rules[i].SourceDynamicObjects = slices.Delete(data.Rules[i].SourceDynamicObjects, ci, ci+1)
+				ci--
+
+				continue
+			}
 			if value := cr.Get("id"); value.Exists() && !data.Rules[i].SourceDynamicObjects[ci].Id.IsNull() {
 				data.Rules[i].SourceDynamicObjects[ci].Id = types.StringValue(value.String())
 			} else {
 				data.Rules[i].SourceDynamicObjects[ci].Id = types.StringNull()
 			}
 		}
-		for ci := range data.Rules[i].DestinationDynamicObjects {
+		for ci := 0; ci < len(data.Rules[i].DestinationDynamicObjects); ci++ {
 			keys := [...]string{"id"}
 			keyValues := [...]string{data.Rules[i].DestinationDynamicObjects[ci].Id.ValueString()}
 
@@ -1154,13 +1204,23 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 					return true
 				},
 			)
+			if !cr.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].DestinationDynamicObjects[%d] = %+v",
+					ci,
+					data.Rules[i].DestinationDynamicObjects[ci],
+				))
+				data.Rules[i].DestinationDynamicObjects = slices.Delete(data.Rules[i].DestinationDynamicObjects, ci, ci+1)
+				ci--
+
+				continue
+			}
 			if value := cr.Get("id"); value.Exists() && !data.Rules[i].DestinationDynamicObjects[ci].Id.IsNull() {
 				data.Rules[i].DestinationDynamicObjects[ci].Id = types.StringValue(value.String())
 			} else {
 				data.Rules[i].DestinationDynamicObjects[ci].Id = types.StringNull()
 			}
 		}
-		for ci := range data.Rules[i].SourcePortObjects {
+		for ci := 0; ci < len(data.Rules[i].SourcePortObjects); ci++ {
 			keys := [...]string{"id"}
 			keyValues := [...]string{data.Rules[i].SourcePortObjects[ci].Id.ValueString()}
 
@@ -1182,13 +1242,23 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 					return true
 				},
 			)
+			if !cr.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].SourcePortObjects[%d] = %+v",
+					ci,
+					data.Rules[i].SourcePortObjects[ci],
+				))
+				data.Rules[i].SourcePortObjects = slices.Delete(data.Rules[i].SourcePortObjects, ci, ci+1)
+				ci--
+
+				continue
+			}
 			if value := cr.Get("id"); value.Exists() && !data.Rules[i].SourcePortObjects[ci].Id.IsNull() {
 				data.Rules[i].SourcePortObjects[ci].Id = types.StringValue(value.String())
 			} else {
 				data.Rules[i].SourcePortObjects[ci].Id = types.StringNull()
 			}
 		}
-		for ci := range data.Rules[i].DestinationPortObjects {
+		for ci := 0; ci < len(data.Rules[i].DestinationPortObjects); ci++ {
 			keys := [...]string{"id"}
 			keyValues := [...]string{data.Rules[i].DestinationPortObjects[ci].Id.ValueString()}
 
@@ -1210,6 +1280,16 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 					return true
 				},
 			)
+			if !cr.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].DestinationPortObjects[%d] = %+v",
+					ci,
+					data.Rules[i].DestinationPortObjects[ci],
+				))
+				data.Rules[i].DestinationPortObjects = slices.Delete(data.Rules[i].DestinationPortObjects, ci, ci+1)
+				ci--
+
+				continue
+			}
 			if value := cr.Get("id"); value.Exists() && !data.Rules[i].DestinationPortObjects[ci].Id.IsNull() {
 				data.Rules[i].DestinationPortObjects[ci].Id = types.StringValue(value.String())
 			} else {
@@ -1239,7 +1319,7 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 				},
 			)
 			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("FIXME will remove items[%d] = %+v",
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].SourceSecurityGroupTagObjects[%d] = %+v",
 					ci,
 					data.Rules[i].SourceSecurityGroupTagObjects[ci],
 				))
@@ -1259,7 +1339,7 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 				data.Rules[i].SourceSecurityGroupTagObjects[ci].Type = types.StringNull()
 			}
 		}
-		for ci := range data.Rules[i].DestinationSecurityGroupTagObjects {
+		for ci := 0; ci < len(data.Rules[i].DestinationSecurityGroupTagObjects); ci++ {
 			keys := [...]string{"id"}
 			keyValues := [...]string{data.Rules[i].DestinationSecurityGroupTagObjects[ci].Id.ValueString()}
 
@@ -1281,6 +1361,16 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 					return true
 				},
 			)
+			if !cr.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].DestinationSecurityGroupTagObjects[%d] = %+v",
+					ci,
+					data.Rules[i].DestinationSecurityGroupTagObjects[ci],
+				))
+				data.Rules[i].DestinationSecurityGroupTagObjects = slices.Delete(data.Rules[i].DestinationSecurityGroupTagObjects, ci, ci+1)
+				ci--
+
+				continue
+			}
 			if value := cr.Get("id"); value.Exists() && !data.Rules[i].DestinationSecurityGroupTagObjects[ci].Id.IsNull() {
 				data.Rules[i].DestinationSecurityGroupTagObjects[ci].Id = types.StringValue(value.String())
 			} else {
@@ -1292,7 +1382,7 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 				data.Rules[i].DestinationSecurityGroupTagObjects[ci].Type = types.StringNull()
 			}
 		}
-		for ci := range data.Rules[i].SourceZones {
+		for ci := 0; ci < len(data.Rules[i].SourceZones); ci++ {
 			keys := [...]string{"id"}
 			keyValues := [...]string{data.Rules[i].SourceZones[ci].Id.ValueString()}
 
@@ -1314,13 +1404,23 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 					return true
 				},
 			)
+			if !cr.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].SourceZones[%d] = %+v",
+					ci,
+					data.Rules[i].SourceZones[ci],
+				))
+				data.Rules[i].SourceZones = slices.Delete(data.Rules[i].SourceZones, ci, ci+1)
+				ci--
+
+				continue
+			}
 			if value := cr.Get("id"); value.Exists() && !data.Rules[i].SourceZones[ci].Id.IsNull() {
 				data.Rules[i].SourceZones[ci].Id = types.StringValue(value.String())
 			} else {
 				data.Rules[i].SourceZones[ci].Id = types.StringNull()
 			}
 		}
-		for ci := range data.Rules[i].DestinationZones {
+		for ci := 0; ci < len(data.Rules[i].DestinationZones); ci++ {
 			keys := [...]string{"id"}
 			keyValues := [...]string{data.Rules[i].DestinationZones[ci].Id.ValueString()}
 
@@ -1342,13 +1442,23 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 					return true
 				},
 			)
+			if !cr.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].DestinationZones[%d] = %+v",
+					ci,
+					data.Rules[i].DestinationZones[ci],
+				))
+				data.Rules[i].DestinationZones = slices.Delete(data.Rules[i].DestinationZones, ci, ci+1)
+				ci--
+
+				continue
+			}
 			if value := cr.Get("id"); value.Exists() && !data.Rules[i].DestinationZones[ci].Id.IsNull() {
 				data.Rules[i].DestinationZones[ci].Id = types.StringValue(value.String())
 			} else {
 				data.Rules[i].DestinationZones[ci].Id = types.StringNull()
 			}
 		}
-		for ci := range data.Rules[i].UrlObjects {
+		for ci := 0; ci < len(data.Rules[i].UrlObjects); ci++ {
 			keys := [...]string{"id"}
 			keyValues := [...]string{data.Rules[i].UrlObjects[ci].Id.ValueString()}
 
@@ -1370,13 +1480,23 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 					return true
 				},
 			)
+			if !cr.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].UrlObjects[%d] = %+v",
+					ci,
+					data.Rules[i].UrlObjects[ci],
+				))
+				data.Rules[i].UrlObjects = slices.Delete(data.Rules[i].UrlObjects, ci, ci+1)
+				ci--
+
+				continue
+			}
 			if value := cr.Get("id"); value.Exists() && !data.Rules[i].UrlObjects[ci].Id.IsNull() {
 				data.Rules[i].UrlObjects[ci].Id = types.StringValue(value.String())
 			} else {
 				data.Rules[i].UrlObjects[ci].Id = types.StringNull()
 			}
 		}
-		for ci := range data.Rules[i].UrlCategories {
+		for ci := 0; ci < len(data.Rules[i].UrlCategories); ci++ {
 			keys := [...]string{"category.id"}
 			keyValues := [...]string{data.Rules[i].UrlCategories[ci].Id.ValueString()}
 
@@ -1398,6 +1518,16 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 					return true
 				},
 			)
+			if !cr.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].UrlCategories[%d] = %+v",
+					ci,
+					data.Rules[i].UrlCategories[ci],
+				))
+				data.Rules[i].UrlCategories = slices.Delete(data.Rules[i].UrlCategories, ci, ci+1)
+				ci--
+
+				continue
+			}
 			if value := cr.Get("category.id"); value.Exists() && !data.Rules[i].UrlCategories[ci].Id.IsNull() {
 				data.Rules[i].UrlCategories[ci].Id = types.StringValue(value.String())
 			} else {

--- a/internal/provider/model_fmc_device_ipv6_static_route.go
+++ b/internal/provider/model_fmc_device_ipv6_static_route.go
@@ -22,8 +22,10 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -156,7 +158,7 @@ func (data *DeviceIPv6StaticRoute) fromBodyPartial(ctx context.Context, res gjso
 	} else {
 		data.InterfaceLogicalName = types.StringNull()
 	}
-	for i := range data.DestinationNetworks {
+	for i := 0; i < len(data.DestinationNetworks); i++ {
 		keys := [...]string{"id"}
 		keyValues := [...]string{data.DestinationNetworks[i].Id.ValueString()}
 
@@ -178,6 +180,16 @@ func (data *DeviceIPv6StaticRoute) fromBodyPartial(ctx context.Context, res gjso
 				return true
 			},
 		)
+		if !r.Exists() {
+			tflog.Debug(ctx, fmt.Sprintf("removing data.DestinationNetworks[%d] = %+v",
+				i,
+				data.DestinationNetworks[i],
+			))
+			data.DestinationNetworks = slices.Delete(data.DestinationNetworks, i, i+1)
+			i--
+
+			continue
+		}
 		if value := r.Get("id"); value.Exists() && !data.DestinationNetworks[i].Id.IsNull() {
 			data.DestinationNetworks[i].Id = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_fmc_device_physical_interface.go
+++ b/internal/provider/model_fmc_device_physical_interface.go
@@ -22,8 +22,10 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -388,7 +390,7 @@ func (data *DevicePhysicalInterface) fromBodyPartial(ctx context.Context, res gj
 	} else {
 		data.Ipv6EnableRa = types.BoolNull()
 	}
-	for i := range data.Ipv6Addresses {
+	for i := 0; i < len(data.Ipv6Addresses); i++ {
 		keys := [...]string{"address", "prefix"}
 		keyValues := [...]string{data.Ipv6Addresses[i].Address.ValueString(), data.Ipv6Addresses[i].Prefix.ValueString()}
 
@@ -410,6 +412,16 @@ func (data *DevicePhysicalInterface) fromBodyPartial(ctx context.Context, res gj
 				return true
 			},
 		)
+		if !r.Exists() {
+			tflog.Debug(ctx, fmt.Sprintf("removing data.Ipv6Addresses[%d] = %+v",
+				i,
+				data.Ipv6Addresses[i],
+			))
+			data.Ipv6Addresses = slices.Delete(data.Ipv6Addresses, i, i+1)
+			i--
+
+			continue
+		}
 		if value := r.Get("address"); value.Exists() && !data.Ipv6Addresses[i].Address.IsNull() {
 			data.Ipv6Addresses[i].Address = types.StringValue(value.String())
 		} else {


### PR DESCRIPTION
Bug replication:

1. In TF create ACP with a rule that has two source zones (note that source_zones is of type: Set).
2. Outside of TF, remove manually the two source zones.
3. `terraform refresh` now fails, trying to save the tfstate where the source_zones Set is invalid.
4. The Set contains two identical empty elements: source_zones == [{}, {}]. What makes it invalid is that Set
cannot contain identical elements.

How is the bug fixed after this change:

Now `terraform refresh` saves the tfstate with no elements: source_zones=[].

If a Read cannot locate the managed element, remove it completely from the tfstate. Do not leave an empty entry.

Do not do this in Create or Update. These methods can only alter Unknown values, and I blindly assume that they are
never given Lists/Sets with any Unknown element (i.e. `AssertTrue(!listset[i].IsUnknown())`).