### PR TITLE
templates: reduce repeated code, add Map

### DIFF
--- a/gen/generator.go
+++ b/gen/generator.go
@@ -504,7 +504,7 @@ func renderTemplate(templatePath, outputPath string, config interface{}) {
 	output := new(bytes.Buffer)
 	err = template.Execute(output, config)
 	if err != nil {
-		log.Fatalf("Error executing template: %v", err)
+		log.Fatalf("Error executing template for %s: %v", outputPath, err)
 	}
 
 	outputFile := filepath.Join(outputPath)

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -95,6 +95,7 @@ var templates = []t{
 
 type YamlConfig struct {
 	Name                string                `yaml:"name"`
+	TfName              string                `yaml:"tf_name"`
 	RestEndpoint        string                `yaml:"rest_endpoint"`
 	PutCreate           bool                  `yaml:"put_create"`
 	NoUpdate            bool                  `yaml:"no_update"`
@@ -380,6 +381,9 @@ func augmentConfig(config *YamlConfig) {
 		} else {
 			config.ResDescription = fmt.Sprintf("This resource can manage a %s.", config.Name)
 		}
+	}
+	if config.TfName == "" {
+		config.TfName = strings.Replace(config.Name, " ", "_", -1)
 	}
 }
 

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -17,7 +17,7 @@ test_prerequisites: str(required=False) # HCL code that is included in the accep
 attribute:
   model_name: str(required=False) # Name of the attribute in the model (payload)
   tf_name: str(required=False) # Name of the attribute in the Terraform resource, by default derived from model_name
-  type: enum('String', 'Int64', 'Float', 'Bool', 'List', 'Set', required=False) # Type of the attribute
+  type: enum('String', 'Int64', 'Float', 'Bool', 'List', 'Map', 'Set', required=False) # Type of the attribute
   element_type: enum('String', 'Int64', required=False) # only relevant if type is either 'List' or 'Set'
   data_path: list(str(), required=False) # Path to the attribute in the model structure
   id: bool(required=False) # Set to true if the attribute is part of the ID

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -38,6 +38,7 @@ attribute:
   max_int: int(required=False) # Maximum value of an integer, only relevant if type is "Int64"
   min_float: num(required=False) # Minimum value of a float, only relevant if type is "Float"
   max_float: num(required=False) # Maximum value of a float, only relevant if type is "Float"
+  map_key_example: str(required=False) # Example value of the map key, only relevant if type is "Map"
   ordered_list: bool(required=False) # Treat `type: List` as strictly ordered. If API ever returns different order, destroy and re-create elements.
   string_patterns: list(str(), required=False) # List of regular expressions that the string must match, only relevant if type is "String"
   string_min_length: int(required=False) # Minimum length of a string, only relevant if type is "String"

--- a/gen/templates/data-source.tf
+++ b/gen/templates/data-source.tf
@@ -1,8 +1,21 @@
+{{- $name := .Name -}}
 data "fmc_{{snakeCase .Name}}" "example" {
   id = "{{$id := false}}{{range .Attributes}}{{if .Id}}{{$id = true}}{{.Example}}{{end}}{{end}}{{if not $id}}76d24097-41c4-4558-a4d0-a8c07ac08470{{end}}"
   {{- range  .Attributes}}
   {{- if .Reference}}
   {{.TfName}} = {{if eq .Type "String"}}"{{.Example}}"{{else if isStringListSet .}}["{{.Example}}"]{{else if isInt64ListSet .}}[{{.Example}}]{{else}}{{.Example}}{{end}}
+  {{- else if isNestedMap .}}
+  {{- $map := .TfName}}
+  {{- $mapkey := .MapKeyExample}}
+  {{.TfName}} = {
+  "{{.MapKeyExample}}" = {
+    {{- range  .Attributes}}
+    {{- if .ResourceId}}
+    {{.TfName}} = fmc_{{snakeCase $name}}.test.{{$map}}["{{$mapkey}}"].{{.TfName}}
+    {{- end}}
+    {{- end}}
+  }
+  }
   {{- end}}
   {{- end}}
 }

--- a/gen/templates/data_source.go
+++ b/gen/templates/data_source.go
@@ -79,7 +79,7 @@ func (d *{{camelCase .Name}}DataSource) Schema(ctx context.Context, req datasour
 			},
 			{{- range  .Attributes}}
 			{{- if not .Value}}
-			"{{.TfName}}": schema.{{if isNestedListSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
+			"{{.TfName}}": schema.{{if isNestedListMapSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
 				MarkdownDescription: "{{.Description}}",
 				{{- if isListSet .}}
 				ElementType:         types.{{.ElementType}}Type,
@@ -92,34 +92,34 @@ func (d *{{camelCase .Name}}DataSource) Schema(ctx context.Context, req datasour
 				{{- end}}
 				Computed:            true,
 				{{- end}}
-				{{- if isNestedListSet .}}
+				{{- if isNestedListMapSet .}}
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						{{- range  .Attributes}}
 						{{- if not .Value}}
-						"{{.TfName}}": schema.{{if isNestedListSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
+						"{{.TfName}}": schema.{{if isNestedListMapSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
 							MarkdownDescription: "{{.Description}}",
 							{{- if isListSet .}}
 							ElementType:         types.{{.ElementType}}Type,
 							{{- end}}
 							Computed:            true,
-							{{- if isNestedListSet .}}
+							{{- if isNestedListMapSet .}}
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									{{- range  .Attributes}}
 									{{- if not .Value}}
-									"{{.TfName}}": schema.{{if isNestedListSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
+									"{{.TfName}}": schema.{{if isNestedListMapSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
 										MarkdownDescription: "{{.Description}}",
 										{{- if isListSet .}}
 										ElementType:         types.{{.ElementType}}Type,
 										{{- end}}
 										Computed:            true,
-										{{- if isNestedListSet .}}
+										{{- if isNestedListMapSet .}}
 										NestedObject: schema.NestedAttributeObject{
 											Attributes: map[string]schema.Attribute{
 												{{- range  .Attributes}}
 												{{- if not .Value}}
-												"{{.TfName}}": schema.{{if isNestedListSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
+												"{{.TfName}}": schema.{{if isNestedListMapSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
 													MarkdownDescription: "{{.Description}}",
 													{{- if isListSet .}}
 													ElementType:         types.{{.ElementType}}Type,

--- a/gen/templates/data_source_test.go
+++ b/gen/templates/data_source_test.go
@@ -154,7 +154,7 @@ func testAccDataSourceFmc{{camelCase .Name}}Config() string {
 	{{- if isNestedListSet .}}
 	config += `	{{.TfName}} = [{` + "\n"
 	{{- else if isNestedMap .}}
-	config += `	{{.TfName}} = { "myname" = {` + "\n"
+	config += `	{{.TfName}} = { "{{.MapKeyExample}}" = {` + "\n"
 	{{- end}}
 		{{- range  .Attributes}}
 		{{- if and (not .ExcludeTest) (not .Value)}}
@@ -238,6 +238,18 @@ func testAccDataSourceFmc{{camelCase .Name}}Config() string {
 			{{- range  .Attributes}}
 			{{- if .Reference}}
 			{{.TfName}} = {{if .TestValue}}{{.TestValue}}{{else}}{{if eq .Type "String"}}"{{.Example}}"{{else if isStringListSet .}}["{{.Example}}"]{{else if isInt64ListSet .}}[{{.Example}}]{{else}}{{.Example}}{{end}}{{end}}
+			{{- else if isNestedMap .}}
+			{{- $map := .TfName}}
+			{{- $mapkey := .MapKeyExample}}
+			{{.TfName}} = {
+				"{{.MapKeyExample}}" = {
+					{{- range  .Attributes}}
+					{{- if .ResourceId}}
+					{{.TfName}} = fmc_{{snakeCase $name}}.test.{{$map}}["{{$mapkey}}"].{{.TfName}}
+					{{- end}}
+					{{- end}}
+				}
+			}
 			{{- end}}
 			{{- end}}
 		}

--- a/gen/templates/data_source_test.go
+++ b/gen/templates/data_source_test.go
@@ -72,7 +72,7 @@ func TestAccDataSourceFmc{{camelCase .Name}}(t *testing.T) {
 	{{- if len .TestTags}}
 	}
 	{{- end}}
-	{{- else if not (isSet .)}}
+	{{- else if not (or (isSet .) (isNestedMap .))}}
 	{{- if len .TestTags}}
 	if {{range $i, $e := .TestTags}}{{if $i}} || {{end}}os.Getenv("{{$e}}") != ""{{end}} {
 		checks = append(checks, resource.TestCheckResourceAttr("data.fmc_{{snakeCase $name}}.test", "{{$list}}.0.{{$clist}}.0.{{.TfName}}{{if isList .}}.0{{end}}", "{{.Example}}"))
@@ -86,7 +86,7 @@ func TestAccDataSourceFmc{{camelCase .Name}}(t *testing.T) {
 	{{- if len .TestTags}}
 	}
 	{{- end}}
-	{{- else if not (isSet .)}}
+	{{- else if not (or (isSet .) (isNestedMap .))}}
 	{{- if len .TestTags}}
 	if {{range $i, $e := .TestTags}}{{if $i}} || {{end}}os.Getenv("{{$e}}") != ""{{end}} {
 		checks = append(checks, resource.TestCheckResourceAttr("data.fmc_{{snakeCase $name}}.test", "{{$list}}.0.{{.TfName}}{{if isList .}}.0{{end}}", "{{.Example}}"))
@@ -100,7 +100,7 @@ func TestAccDataSourceFmc{{camelCase .Name}}(t *testing.T) {
 	{{- if len .TestTags}}
 	}
 	{{- end}}
-	{{- else if not (isSet .)}}
+	{{- else if not (or (isSet .) (isNestedMap .))}}
 	{{- if len .TestTags}}
 	if {{range $i, $e := .TestTags}}{{if $i}} || {{end}}os.Getenv("{{$e}}") != ""{{end}} {
 		checks = append(checks, resource.TestCheckResourceAttr("data.fmc_{{snakeCase $name}}.test", "{{.TfName}}{{if isList .}}.0{{end}}", "{{.Example}}"))
@@ -147,11 +147,15 @@ func testAccDataSourceFmc{{camelCase .Name}}Config() string {
 	config := `resource "fmc_{{snakeCase $name}}" "test" {` + "\n"
 	{{- range  .Attributes}}
 	{{- if and (not .ExcludeTest) (not .Value) (not .ResourceId)}}
-	{{- if isNestedListSet .}}
+	{{- if isNestedListMapSet .}}
 	{{- if len .TestTags}}
 	if {{range $i, $e := .TestTags}}{{if $i}} || {{end}}os.Getenv("{{$e}}") != ""{{end}} {
 	{{- end}}
+	{{- if isNestedListSet .}}
 	config += `	{{.TfName}} = [{` + "\n"
+	{{- else if isNestedMap .}}
+	config += `	{{.TfName}} = { "myname" = {` + "\n"
+	{{- end}}
 		{{- range  .Attributes}}
 		{{- if and (not .ExcludeTest) (not .Value)}}
 		{{- if isNestedListSet .}}
@@ -207,7 +211,11 @@ func testAccDataSourceFmc{{camelCase .Name}}Config() string {
 		{{- end}}
 		{{- end}}
 		{{- end}}
+	{{- if isNestedListSet .}}
 	config += `	}]` + "\n"
+	{{- else if isNestedMap .}}
+	config += `	}}` + "\n"
+	{{- end}}
 		{{- if len .TestTags}}
 	}
 		{{- end}}

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -260,9 +260,9 @@ func (data {{camelCase .Name}}) toBody(ctx context.Context, state {{camelCase .N
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBody
 
 func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result) {
+{{- define "fromBodyTemplate"}}
 	{{- range .Attributes}}
 	{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
-	{{- $cname := toGoName .TfName}}
 	{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
 	if value := res.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); value.Exists() {
 		data.{{toGoName .TfName}} = types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
@@ -281,98 +281,31 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 	}
 	{{- else if isNestedListSet .}}
 	if value := res{{if .ModelName}}.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"){{end}}; value.Exists() {
-		data.{{toGoName .TfName}} = make([]{{$name}}{{toGoName .TfName}}, 0)
-		value.ForEach(func(k, v gjson.Result) bool {
-			item := {{$name}}{{toGoName .TfName}}{}
-			{{- range .Attributes}}
-			{{- $ccname := toGoName .TfName}}
-			{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
-			{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
-			if cValue := v.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); cValue.Exists() {
-				item.{{toGoName .TfName}} = types.{{.Type}}Value(cValue.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
-			} else {
-				{{- if .DefaultValue}}
-				item.{{toGoName .TfName}} = types.{{.Type}}Value({{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}})
-				{{- else}}
-				item.{{toGoName .TfName}} = types.{{.Type}}Null()
-				{{- end}}
-			}
-			{{- else if isListSet .}}
-			if cValue := v.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); cValue.Exists() {
-				item.{{toGoName .TfName}} = helpers.Get{{.ElementType}}{{.Type}}(cValue.Array())
-			} else {
-				item.{{toGoName .TfName}} = types.{{.Type}}Null(types.{{.ElementType}}Type)
-			}
-			{{- else if isNestedListSet .}}
-			if cValue := v.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); cValue.Exists() {
-				item.{{toGoName .TfName}} = make([]{{$name}}{{$cname}}{{toGoName .TfName}}, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := {{$name}}{{$cname}}{{toGoName .TfName}}{}
-					{{- range .Attributes}}
-					{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
-					{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
-					if ccValue := cv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); ccValue.Exists() {
-						cItem.{{toGoName .TfName}} = types.{{.Type}}Value(ccValue.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
-					} else {
-						{{- if .DefaultValue}}
-						cItem.{{toGoName .TfName}} = types.{{.Type}}Value({{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}})
-						{{- else}}
-						cItem.{{toGoName .TfName}} = types.{{.Type}}Null()
-						{{- end}}
-					}
-					{{- else if isListSet .}}
-					if ccValue := cv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); ccValue.Exists() {
-						cItem.{{toGoName .TfName}} = helpers.Get{{.ElementType}}{{.Type}}(ccValue.Array())
-					} else {
-						cItem.{{toGoName .TfName}} = types.{{.Type}}Null(types.{{.ElementType}}Type)
-					}
-					{{- else if isNestedListSet .}}
-					if ccValue := cv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); ccValue.Exists() {
-						cItem.{{toGoName .TfName}} = make([]{{$name}}{{$cname}}{{$ccname}}{{toGoName .TfName}}, 0)
-						ccValue.ForEach(func(cck, ccv gjson.Result) bool {
-							ccItem := {{$name}}{{$cname}}{{$ccname}}{{toGoName .TfName}}{}
-							{{- range .Attributes}}
-							{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
-							{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
-							if cccValue := ccv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); cccValue.Exists() {
-								ccItem.{{toGoName .TfName}} = types.{{.Type}}Value(cccValue.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
-							} else {
-								{{- if .DefaultValue}}
-								ccItem.{{toGoName .TfName}} = types.{{.Type}}Value({{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}})
-								{{- else}}
-								ccItem.{{toGoName .TfName}} = types.{{.Type}}Null()
-								{{- end}}
-							}
-							{{- else if isListSet .}}
-							if cccValue := ccv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); cccValue.Exists() {
-								ccItem.{{toGoName .TfName}} = helpers.Get{{.ElementType}}{{.Type}}(cccValue.Array())
-							} else {
-								ccItem.{{toGoName .TfName}} = types.{{.Type}}Null(types.{{.ElementType}}Type)
-							}
-							{{- end}}
-							{{- end}}
-							{{- end}}
-							cItem.{{toGoName .TfName}} = append(cItem.{{toGoName .TfName}}, ccItem)
-							return true
-						})
-					}
-					{{- end}}
-					{{- end}}
-					{{- end}}
-					item.{{toGoName .TfName}} = append(item.{{toGoName .TfName}}, cItem)
-					return true
-				})
-			}
-			{{- end}}
-			{{- end}}
-			{{- end}}
-			data.{{toGoName .TfName}} = append(data.{{toGoName .TfName}}, item)
+		data.{{toGoName .TfName}} = make([]{{.GoTypeName}}, 0)
+		value.ForEach(func(k, res gjson.Result) bool {
+			parent := &data
+			data := {{.GoTypeName}}{}
+			{{- template "fromBodyTemplate" .}}
+			(*parent).{{toGoName .TfName}} = append((*parent).{{toGoName .TfName}}, data)
+			return true
+		})
+	}
+	{{- else if isNestedMap .}}
+	if value := res{{if .ModelName}}.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"){{end}}; value.Exists() {
+		data.{{toGoName .TfName}} = map[string]{{.GoTypeName}}{}
+		value.ForEach(func(k, res gjson.Result) bool {
+			parent := &data
+			data := {{.GoTypeName}}{}
+			{{- template "fromBodyTemplate" .}}
+			(*parent).{{toGoName .TfName}}[res.Get("name").String()] = data
 			return true
 		})
 	}
 	{{- end}}
 	{{- end}}
 	{{- end}}
+{{- end}}
+{{- template "fromBodyTemplate" .}}
 }
 
 // End of section. //template:end fromBody

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -225,7 +225,6 @@ func (data {{camelCase .Name}}) toBody(ctx context.Context, state {{camelCase .N
 							if !childChildItem.{{toGoName .TfName}}.IsNull() {
 								itemChildChildBody, _ = sjson.Set(itemChildChildBody, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}", childChildItem.{{toGoName .TfName}}.Value{{.Type}}())
 							}
-							{{- errorf "element_type is not yet implemented for type Map at this depth"}}
 							{{- else if isListSet .}}
 							if !childChildItem.{{toGoName .TfName}}.IsNull() {
 								var values []{{if isStringListSet .}}string{{else if isInt64ListSet .}}int64{{end}}
@@ -563,3 +562,43 @@ func (data *{{camelCase .Name}}) fromBodyUnknowns(ctx context.Context, res gjson
 }
 
 // End of section. //template:end fromBodyUnknowns
+{{- range .Attributes}}
+	{{- range .Attributes}}
+		{{- if isNestedMap .}}
+			{{- errorf "Map not yet implemented at this depth"}}
+		{{- end}}
+		{{- if .OrderedList }}
+			{{- errorf "ordered_list not yet implemented at this depth"}}
+		{{- end}}
+		{{- if hasResourceId .Attributes}}
+			{{- errorf "resource_id not yet implemented at this depth"}}
+		{{- end}}
+
+		{{- range .Attributes}}
+			{{- if isNestedMap .}}
+				{{- errorf "Map not yet implemented at this depth"}}
+			{{- end}}
+			{{- if .OrderedList }}
+				{{- errorf "ordered_list not yet implemented at this depth"}}
+			{{- end}}
+			{{- if hasResourceId .Attributes}}
+				{{- errorf "resource_id not yet implemented at this depth"}}
+			{{- end}}
+
+			{{- range .Attributes}}
+				{{- if isNestedMap .}}
+					{{- errorf "Map not yet implemented at this depth"}}
+				{{- end}}
+				{{- if .OrderedList }}
+					{{- errorf "ordered_list not yet implemented at this depth"}}
+				{{- end}}
+				{{- if hasResourceId .Attributes}}
+					{{- errorf "resource_id not yet implemented at this depth"}}
+				{{- end}}
+				{{- range .Attributes}}
+					{{- errorf "attributes not yet implemented at this depth"}}
+				{{- end}}
+			{{- end}}
+		{{- end}}
+	{{- end}}
+{{- end}}

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -541,8 +541,7 @@ func (data *{{camelCase .Name}}) fromBodyUnknowns(ctx context.Context, res gjson
 		{{- range .Attributes}}
 		{{- if and .ResourceId (not .Reference)}}
 		{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
-		if data.{{$list}}[i].{{toGoName .TfName}}.IsUnknown() {
-			v := data.{{$list}}[i]
+		if v := data.{{$list}}[i]; v.{{toGoName .TfName}}.IsUnknown() {
 			if value := r.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); value.Exists() {
 				v.{{toGoName .TfName}} = types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
 			} else {

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -87,7 +87,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 			},
 			{{- range  .Attributes}}
 			{{- if not .Value}}
-			"{{.TfName}}": schema.{{if isNestedListSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
+			"{{.TfName}}": schema.{{if isNestedListMapSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
 				MarkdownDescription: helpers.NewAttributeDescription("{{.Description}}")
 					{{- if len .EnumValues -}}
 					.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
@@ -147,12 +147,12 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 					{{snakeCase .Type}}planmodifier.RequiresReplace(),
 				},
 				{{- end}}
-				{{- if isNestedListSet .}}
+				{{- if isNestedListMapSet .}}
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						{{- range  .Attributes}}
 						{{- if not .Value}}
-						"{{.TfName}}": schema.{{if isNestedListSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
+						"{{.TfName}}": schema.{{if isNestedListMapSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
 							MarkdownDescription: helpers.NewAttributeDescription("{{.Description}}")
 								{{- if len .EnumValues -}}
 								.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
@@ -212,12 +212,12 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 								{{snakeCase .Type}}planmodifier.RequiresReplace(),
 							},
 							{{- end}}
-							{{- if isNestedListSet .}}
+							{{- if isNestedListMapSet .}}
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									{{- range  .Attributes}}
 									{{- if not .Value}}
-									"{{.TfName}}": schema.{{if isNestedListSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
+									"{{.TfName}}": schema.{{if isNestedListMapSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
 										MarkdownDescription: helpers.NewAttributeDescription("{{.Description}}")
 											{{- if len .EnumValues -}}
 											.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
@@ -277,12 +277,12 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 											{{snakeCase .Type}}planmodifier.RequiresReplace(),
 										},
 										{{- end}}
-										{{- if isNestedListSet .}}
+										{{- if isNestedListMapSet .}}
 										NestedObject: schema.NestedAttributeObject{
 											Attributes: map[string]schema.Attribute{
 												{{- range  .Attributes}}
 												{{- if not .Value}}
-												"{{.TfName}}": schema.{{if isNestedListSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
+												"{{.TfName}}": schema.{{if isNestedListMapSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
 													MarkdownDescription: helpers.NewAttributeDescription("{{.Description}}")
 														{{- if len .EnumValues -}}
 														.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -148,6 +148,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 				},
 				{{- end}}
 				{{- if isNestedListMapSet .}}
+				{{- $useStateForUnknown := isNestedMap .}}
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						{{- range  .Attributes}}
@@ -207,7 +208,11 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 							{{- else if and (len .DefaultValue) (eq .Type "String")}}
 							Default:             stringdefault.StaticString("{{.DefaultValue}}"),
 							{{- end}}
-							{{- if .RequiresReplace}}
+							{{- if and .ResourceId $useStateForUnknown}}
+							PlanModifiers: []planmodifier.{{.Type}}{
+								{{snakeCase .Type}}planmodifier.UseStateForUnknown(),
+							},
+							{{- else if .RequiresReplace}}
 							PlanModifiers: []planmodifier.{{.Type}}{
 								{{snakeCase .Type}}planmodifier.RequiresReplace(),
 							},

--- a/gen/templates/resource.tf
+++ b/gen/templates/resource.tf
@@ -1,9 +1,15 @@
 resource "fmc_{{snakeCase .Name}}" "example" {
 {{- range  .Attributes}}
 {{- if and (not .ExcludeExample) (not .Value) (not .ResourceId)}}
-{{- if isNestedListSet .}}
-  {{.TfName}} = [
+{{- if isNestedListMapSet .}}
+  {{.TfName}} =
+  {{- if isNestedListSet . -}}
+  [
     {
+  {{- else -}}
+  {
+    {{.MapKeyExample}} = {
+  {{- end}}
       {{- range  .Attributes}}
       {{- if and (not .ExcludeExample) (not .Value)}}
       {{- if isNestedListSet .}}
@@ -34,7 +40,11 @@ resource "fmc_{{snakeCase .Name}}" "example" {
       {{- end}}
       {{- end}}
     }
+  {{- if isNestedListSet .}}
   ]
+  {{- else}}
+  }
+  {{- end}}
 {{- else}}
   {{.TfName}} = {{if eq .Type "String"}}"{{.Example}}"{{else if isStringListSet .}}["{{.Example}}"]{{else if isInt64ListSet .}}[{{.Example}}]{{else}}{{.Example}}{{end}}
 {{- end}}

--- a/gen/templates/resource_test.go
+++ b/gen/templates/resource_test.go
@@ -72,7 +72,7 @@ func TestAccFmc{{camelCase .Name}}(t *testing.T) {
 	{{- if len .TestTags}}
 	}
 	{{- end}}
-	{{- else if not (isSet .)}}
+	{{- else if not (or (isSet .) (isNestedMap .))}}
 	{{- if len .TestTags}}
 	if {{range $i, $e := .TestTags}}{{if $i}} || {{end}}os.Getenv("{{$e}}") != ""{{end}} {
 		checks = append(checks, resource.TestCheckResourceAttr("fmc_{{snakeCase $name}}.test", "{{$list}}.0.{{$clist}}.0.{{.TfName}}{{if isList .}}.0{{end}}", "{{.Example}}"))
@@ -86,7 +86,7 @@ func TestAccFmc{{camelCase .Name}}(t *testing.T) {
 	{{- if len .TestTags}}
 	}
 	{{- end}}
-	{{- else if not (isSet .)}}
+	{{- else if not (or (isSet .) (isNestedMap .))}}
 	{{- if len .TestTags}}
 	if {{range $i, $e := .TestTags}}{{if $i}} || {{end}}os.Getenv("{{$e}}") != ""{{end}} {
 		checks = append(checks, resource.TestCheckResourceAttr("fmc_{{snakeCase $name}}.test", "{{$list}}.0.{{.TfName}}{{if isList .}}.0{{end}}", "{{.Example}}"))
@@ -100,7 +100,7 @@ func TestAccFmc{{camelCase .Name}}(t *testing.T) {
 	{{- if len .TestTags}}
 	}
 	{{- end}}
-	{{- else if not (isSet .)}}
+	{{- else if not (or (isSet .) (isNestedMap .))}}
 	{{- if len .TestTags}}
 	if {{range $i, $e := .TestTags}}{{if $i}} || {{end}}os.Getenv("{{$e}}") != ""{{end}} {
 		checks = append(checks, resource.TestCheckResourceAttr("fmc_{{snakeCase $name}}.test", "{{.TfName}}{{if isList .}}.0{{end}}", "{{.Example}}"))
@@ -243,11 +243,15 @@ func testAccFmc{{camelCase .Name}}Config_all() string {
 	config := `resource "fmc_{{snakeCase $name}}" "test" {` + "\n"
 	{{- range  .Attributes}}
 	{{- if and (not .ExcludeTest) (not .Value) (not .ResourceId)}}
-	{{- if isNestedListSet .}}
+	{{- if isNestedListMapSet .}}
 	{{- if len .TestTags}}
 	if {{range $i, $e := .TestTags}}{{if $i}} || {{end}}os.Getenv("{{$e}}") != ""{{end}} {
 	{{- end}}
+	{{- if isNestedListSet .}}
 	config += `	{{.TfName}} = [{` + "\n"
+	{{- else if isNestedMap .}}
+	config += `	{{.TfName}} = { "{{.MapKeyExample}}" = {` + "\n"
+	{{- end}}
 		{{- range  .Attributes}}
 		{{- if and (not .ExcludeTest) (not .Value)}}
 		{{- if isNestedListSet .}}
@@ -303,7 +307,11 @@ func testAccFmc{{camelCase .Name}}Config_all() string {
 		{{- end}}
 		{{- end}}
 		{{- end}}
+	{{- if isNestedListSet .}}
 	config += `	}]` + "\n"
+	{{- else if isNestedMap .}}
+	config += `	}}` + "\n"
+	{{- end}}
 		{{- if len .TestTags}}
 	}
 		{{- end}}

--- a/internal/provider/model_fmc_access_control_policy.go
+++ b/internal/provider/model_fmc_access_control_policy.go
@@ -535,314 +535,330 @@ func (data *AccessControlPolicy) fromBody(ctx context.Context, res gjson.Result)
 	}
 	if value := res.Get("dummy_categories"); value.Exists() {
 		data.Categories = make([]AccessControlPolicyCategories, 0)
-		value.ForEach(func(k, v gjson.Result) bool {
-			item := AccessControlPolicyCategories{}
-			if cValue := v.Get("id"); cValue.Exists() {
-				item.Id = types.StringValue(cValue.String())
+		value.ForEach(func(k, res gjson.Result) bool {
+			parent := &data
+			data := AccessControlPolicyCategories{}
+			if value := res.Get("id"); value.Exists() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				item.Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
-			if cValue := v.Get("name"); cValue.Exists() {
-				item.Name = types.StringValue(cValue.String())
+			if value := res.Get("name"); value.Exists() {
+				data.Name = types.StringValue(value.String())
 			} else {
-				item.Name = types.StringNull()
+				data.Name = types.StringNull()
 			}
-			data.Categories = append(data.Categories, item)
+			(*parent).Categories = append((*parent).Categories, data)
 			return true
 		})
 	}
 	if value := res.Get("dummy_rules"); value.Exists() {
 		data.Rules = make([]AccessControlPolicyRules, 0)
-		value.ForEach(func(k, v gjson.Result) bool {
-			item := AccessControlPolicyRules{}
-			if cValue := v.Get("id"); cValue.Exists() {
-				item.Id = types.StringValue(cValue.String())
+		value.ForEach(func(k, res gjson.Result) bool {
+			parent := &data
+			data := AccessControlPolicyRules{}
+			if value := res.Get("id"); value.Exists() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				item.Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
-			if cValue := v.Get("action"); cValue.Exists() {
-				item.Action = types.StringValue(cValue.String())
+			if value := res.Get("action"); value.Exists() {
+				data.Action = types.StringValue(value.String())
 			} else {
-				item.Action = types.StringNull()
+				data.Action = types.StringNull()
 			}
-			if cValue := v.Get("name"); cValue.Exists() {
-				item.Name = types.StringValue(cValue.String())
+			if value := res.Get("name"); value.Exists() {
+				data.Name = types.StringValue(value.String())
 			} else {
-				item.Name = types.StringNull()
+				data.Name = types.StringNull()
 			}
-			if cValue := v.Get("metadata.category"); cValue.Exists() {
-				item.CategoryName = types.StringValue(cValue.String())
+			if value := res.Get("metadata.category"); value.Exists() {
+				data.CategoryName = types.StringValue(value.String())
 			} else {
-				item.CategoryName = types.StringNull()
+				data.CategoryName = types.StringNull()
 			}
-			if cValue := v.Get("metadata.section"); cValue.Exists() {
-				item.Section = types.StringValue(cValue.String())
+			if value := res.Get("metadata.section"); value.Exists() {
+				data.Section = types.StringValue(value.String())
 			} else {
-				item.Section = types.StringNull()
+				data.Section = types.StringNull()
 			}
-			if cValue := v.Get("enabled"); cValue.Exists() {
-				item.Enabled = types.BoolValue(cValue.Bool())
+			if value := res.Get("enabled"); value.Exists() {
+				data.Enabled = types.BoolValue(value.Bool())
 			} else {
-				item.Enabled = types.BoolValue(true)
+				data.Enabled = types.BoolValue(true)
 			}
-			if cValue := v.Get("sourceNetworks.literals"); cValue.Exists() {
-				item.SourceNetworkLiterals = make([]AccessControlPolicyRulesSourceNetworkLiterals, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesSourceNetworkLiterals{}
-					if ccValue := cv.Get("value"); ccValue.Exists() {
-						cItem.Value = types.StringValue(ccValue.String())
+			if value := res.Get("sourceNetworks.literals"); value.Exists() {
+				data.SourceNetworkLiterals = make([]AccessControlPolicyRulesSourceNetworkLiterals, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesSourceNetworkLiterals{}
+					if value := res.Get("value"); value.Exists() {
+						data.Value = types.StringValue(value.String())
 					} else {
-						cItem.Value = types.StringNull()
+						data.Value = types.StringNull()
 					}
-					item.SourceNetworkLiterals = append(item.SourceNetworkLiterals, cItem)
+					(*parent).SourceNetworkLiterals = append((*parent).SourceNetworkLiterals, data)
 					return true
 				})
 			}
-			if cValue := v.Get("destinationNetworks.literals"); cValue.Exists() {
-				item.DestinationNetworkLiterals = make([]AccessControlPolicyRulesDestinationNetworkLiterals, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesDestinationNetworkLiterals{}
-					if ccValue := cv.Get("value"); ccValue.Exists() {
-						cItem.Value = types.StringValue(ccValue.String())
+			if value := res.Get("destinationNetworks.literals"); value.Exists() {
+				data.DestinationNetworkLiterals = make([]AccessControlPolicyRulesDestinationNetworkLiterals, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesDestinationNetworkLiterals{}
+					if value := res.Get("value"); value.Exists() {
+						data.Value = types.StringValue(value.String())
 					} else {
-						cItem.Value = types.StringNull()
+						data.Value = types.StringNull()
 					}
-					item.DestinationNetworkLiterals = append(item.DestinationNetworkLiterals, cItem)
+					(*parent).DestinationNetworkLiterals = append((*parent).DestinationNetworkLiterals, data)
 					return true
 				})
 			}
-			if cValue := v.Get("sourceNetworks.objects"); cValue.Exists() {
-				item.SourceNetworkObjects = make([]AccessControlPolicyRulesSourceNetworkObjects, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesSourceNetworkObjects{}
-					if ccValue := cv.Get("id"); ccValue.Exists() {
-						cItem.Id = types.StringValue(ccValue.String())
+			if value := res.Get("sourceNetworks.objects"); value.Exists() {
+				data.SourceNetworkObjects = make([]AccessControlPolicyRulesSourceNetworkObjects, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesSourceNetworkObjects{}
+					if value := res.Get("id"); value.Exists() {
+						data.Id = types.StringValue(value.String())
 					} else {
-						cItem.Id = types.StringNull()
+						data.Id = types.StringNull()
 					}
-					if ccValue := cv.Get("type"); ccValue.Exists() {
-						cItem.Type = types.StringValue(ccValue.String())
+					if value := res.Get("type"); value.Exists() {
+						data.Type = types.StringValue(value.String())
 					} else {
-						cItem.Type = types.StringNull()
+						data.Type = types.StringNull()
 					}
-					item.SourceNetworkObjects = append(item.SourceNetworkObjects, cItem)
+					(*parent).SourceNetworkObjects = append((*parent).SourceNetworkObjects, data)
 					return true
 				})
 			}
-			if cValue := v.Get("destinationNetworks.objects"); cValue.Exists() {
-				item.DestinationNetworkObjects = make([]AccessControlPolicyRulesDestinationNetworkObjects, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesDestinationNetworkObjects{}
-					if ccValue := cv.Get("id"); ccValue.Exists() {
-						cItem.Id = types.StringValue(ccValue.String())
+			if value := res.Get("destinationNetworks.objects"); value.Exists() {
+				data.DestinationNetworkObjects = make([]AccessControlPolicyRulesDestinationNetworkObjects, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesDestinationNetworkObjects{}
+					if value := res.Get("id"); value.Exists() {
+						data.Id = types.StringValue(value.String())
 					} else {
-						cItem.Id = types.StringNull()
+						data.Id = types.StringNull()
 					}
-					if ccValue := cv.Get("type"); ccValue.Exists() {
-						cItem.Type = types.StringValue(ccValue.String())
+					if value := res.Get("type"); value.Exists() {
+						data.Type = types.StringValue(value.String())
 					} else {
-						cItem.Type = types.StringNull()
+						data.Type = types.StringNull()
 					}
-					item.DestinationNetworkObjects = append(item.DestinationNetworkObjects, cItem)
+					(*parent).DestinationNetworkObjects = append((*parent).DestinationNetworkObjects, data)
 					return true
 				})
 			}
-			if cValue := v.Get("sourceDynamicObjects.objects"); cValue.Exists() {
-				item.SourceDynamicObjects = make([]AccessControlPolicyRulesSourceDynamicObjects, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesSourceDynamicObjects{}
-					if ccValue := cv.Get("id"); ccValue.Exists() {
-						cItem.Id = types.StringValue(ccValue.String())
+			if value := res.Get("sourceDynamicObjects.objects"); value.Exists() {
+				data.SourceDynamicObjects = make([]AccessControlPolicyRulesSourceDynamicObjects, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesSourceDynamicObjects{}
+					if value := res.Get("id"); value.Exists() {
+						data.Id = types.StringValue(value.String())
 					} else {
-						cItem.Id = types.StringNull()
+						data.Id = types.StringNull()
 					}
-					item.SourceDynamicObjects = append(item.SourceDynamicObjects, cItem)
+					(*parent).SourceDynamicObjects = append((*parent).SourceDynamicObjects, data)
 					return true
 				})
 			}
-			if cValue := v.Get("destinationDynamicObjects.objects"); cValue.Exists() {
-				item.DestinationDynamicObjects = make([]AccessControlPolicyRulesDestinationDynamicObjects, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesDestinationDynamicObjects{}
-					if ccValue := cv.Get("id"); ccValue.Exists() {
-						cItem.Id = types.StringValue(ccValue.String())
+			if value := res.Get("destinationDynamicObjects.objects"); value.Exists() {
+				data.DestinationDynamicObjects = make([]AccessControlPolicyRulesDestinationDynamicObjects, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesDestinationDynamicObjects{}
+					if value := res.Get("id"); value.Exists() {
+						data.Id = types.StringValue(value.String())
 					} else {
-						cItem.Id = types.StringNull()
+						data.Id = types.StringNull()
 					}
-					item.DestinationDynamicObjects = append(item.DestinationDynamicObjects, cItem)
+					(*parent).DestinationDynamicObjects = append((*parent).DestinationDynamicObjects, data)
 					return true
 				})
 			}
-			if cValue := v.Get("sourcePorts.objects"); cValue.Exists() {
-				item.SourcePortObjects = make([]AccessControlPolicyRulesSourcePortObjects, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesSourcePortObjects{}
-					if ccValue := cv.Get("id"); ccValue.Exists() {
-						cItem.Id = types.StringValue(ccValue.String())
+			if value := res.Get("sourcePorts.objects"); value.Exists() {
+				data.SourcePortObjects = make([]AccessControlPolicyRulesSourcePortObjects, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesSourcePortObjects{}
+					if value := res.Get("id"); value.Exists() {
+						data.Id = types.StringValue(value.String())
 					} else {
-						cItem.Id = types.StringNull()
+						data.Id = types.StringNull()
 					}
-					item.SourcePortObjects = append(item.SourcePortObjects, cItem)
+					(*parent).SourcePortObjects = append((*parent).SourcePortObjects, data)
 					return true
 				})
 			}
-			if cValue := v.Get("destinationPorts.objects"); cValue.Exists() {
-				item.DestinationPortObjects = make([]AccessControlPolicyRulesDestinationPortObjects, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesDestinationPortObjects{}
-					if ccValue := cv.Get("id"); ccValue.Exists() {
-						cItem.Id = types.StringValue(ccValue.String())
+			if value := res.Get("destinationPorts.objects"); value.Exists() {
+				data.DestinationPortObjects = make([]AccessControlPolicyRulesDestinationPortObjects, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesDestinationPortObjects{}
+					if value := res.Get("id"); value.Exists() {
+						data.Id = types.StringValue(value.String())
 					} else {
-						cItem.Id = types.StringNull()
+						data.Id = types.StringNull()
 					}
-					item.DestinationPortObjects = append(item.DestinationPortObjects, cItem)
+					(*parent).DestinationPortObjects = append((*parent).DestinationPortObjects, data)
 					return true
 				})
 			}
-			if cValue := v.Get("sourceSecurityGroupTags.objects"); cValue.Exists() {
-				item.SourceSecurityGroupTagObjects = make([]AccessControlPolicyRulesSourceSecurityGroupTagObjects, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesSourceSecurityGroupTagObjects{}
-					if ccValue := cv.Get("id"); ccValue.Exists() {
-						cItem.Id = types.StringValue(ccValue.String())
+			if value := res.Get("sourceSecurityGroupTags.objects"); value.Exists() {
+				data.SourceSecurityGroupTagObjects = make([]AccessControlPolicyRulesSourceSecurityGroupTagObjects, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesSourceSecurityGroupTagObjects{}
+					if value := res.Get("id"); value.Exists() {
+						data.Id = types.StringValue(value.String())
 					} else {
-						cItem.Id = types.StringNull()
+						data.Id = types.StringNull()
 					}
-					if ccValue := cv.Get("type"); ccValue.Exists() {
-						cItem.Type = types.StringValue(ccValue.String())
+					if value := res.Get("type"); value.Exists() {
+						data.Type = types.StringValue(value.String())
 					} else {
-						cItem.Type = types.StringNull()
+						data.Type = types.StringNull()
 					}
-					item.SourceSecurityGroupTagObjects = append(item.SourceSecurityGroupTagObjects, cItem)
+					(*parent).SourceSecurityGroupTagObjects = append((*parent).SourceSecurityGroupTagObjects, data)
 					return true
 				})
 			}
-			if cValue := v.Get("destinationSecurityGroupTags.objects"); cValue.Exists() {
-				item.DestinationSecurityGroupTagObjects = make([]AccessControlPolicyRulesDestinationSecurityGroupTagObjects, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesDestinationSecurityGroupTagObjects{}
-					if ccValue := cv.Get("id"); ccValue.Exists() {
-						cItem.Id = types.StringValue(ccValue.String())
+			if value := res.Get("destinationSecurityGroupTags.objects"); value.Exists() {
+				data.DestinationSecurityGroupTagObjects = make([]AccessControlPolicyRulesDestinationSecurityGroupTagObjects, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesDestinationSecurityGroupTagObjects{}
+					if value := res.Get("id"); value.Exists() {
+						data.Id = types.StringValue(value.String())
 					} else {
-						cItem.Id = types.StringNull()
+						data.Id = types.StringNull()
 					}
-					if ccValue := cv.Get("type"); ccValue.Exists() {
-						cItem.Type = types.StringValue(ccValue.String())
+					if value := res.Get("type"); value.Exists() {
+						data.Type = types.StringValue(value.String())
 					} else {
-						cItem.Type = types.StringNull()
+						data.Type = types.StringNull()
 					}
-					item.DestinationSecurityGroupTagObjects = append(item.DestinationSecurityGroupTagObjects, cItem)
+					(*parent).DestinationSecurityGroupTagObjects = append((*parent).DestinationSecurityGroupTagObjects, data)
 					return true
 				})
 			}
-			if cValue := v.Get("sourceZones.objects"); cValue.Exists() {
-				item.SourceZones = make([]AccessControlPolicyRulesSourceZones, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesSourceZones{}
-					if ccValue := cv.Get("id"); ccValue.Exists() {
-						cItem.Id = types.StringValue(ccValue.String())
+			if value := res.Get("sourceZones.objects"); value.Exists() {
+				data.SourceZones = make([]AccessControlPolicyRulesSourceZones, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesSourceZones{}
+					if value := res.Get("id"); value.Exists() {
+						data.Id = types.StringValue(value.String())
 					} else {
-						cItem.Id = types.StringNull()
+						data.Id = types.StringNull()
 					}
-					item.SourceZones = append(item.SourceZones, cItem)
+					(*parent).SourceZones = append((*parent).SourceZones, data)
 					return true
 				})
 			}
-			if cValue := v.Get("destinationZones.objects"); cValue.Exists() {
-				item.DestinationZones = make([]AccessControlPolicyRulesDestinationZones, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesDestinationZones{}
-					if ccValue := cv.Get("id"); ccValue.Exists() {
-						cItem.Id = types.StringValue(ccValue.String())
+			if value := res.Get("destinationZones.objects"); value.Exists() {
+				data.DestinationZones = make([]AccessControlPolicyRulesDestinationZones, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesDestinationZones{}
+					if value := res.Get("id"); value.Exists() {
+						data.Id = types.StringValue(value.String())
 					} else {
-						cItem.Id = types.StringNull()
+						data.Id = types.StringNull()
 					}
-					item.DestinationZones = append(item.DestinationZones, cItem)
+					(*parent).DestinationZones = append((*parent).DestinationZones, data)
 					return true
 				})
 			}
-			if cValue := v.Get("urls.objects"); cValue.Exists() {
-				item.UrlObjects = make([]AccessControlPolicyRulesUrlObjects, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesUrlObjects{}
-					if ccValue := cv.Get("id"); ccValue.Exists() {
-						cItem.Id = types.StringValue(ccValue.String())
+			if value := res.Get("urls.objects"); value.Exists() {
+				data.UrlObjects = make([]AccessControlPolicyRulesUrlObjects, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesUrlObjects{}
+					if value := res.Get("id"); value.Exists() {
+						data.Id = types.StringValue(value.String())
 					} else {
-						cItem.Id = types.StringNull()
+						data.Id = types.StringNull()
 					}
-					item.UrlObjects = append(item.UrlObjects, cItem)
+					(*parent).UrlObjects = append((*parent).UrlObjects, data)
 					return true
 				})
 			}
-			if cValue := v.Get("urls.urlCategoriesWithReputation"); cValue.Exists() {
-				item.UrlCategories = make([]AccessControlPolicyRulesUrlCategories, 0)
-				cValue.ForEach(func(ck, cv gjson.Result) bool {
-					cItem := AccessControlPolicyRulesUrlCategories{}
-					if ccValue := cv.Get("category.id"); ccValue.Exists() {
-						cItem.Id = types.StringValue(ccValue.String())
+			if value := res.Get("urls.urlCategoriesWithReputation"); value.Exists() {
+				data.UrlCategories = make([]AccessControlPolicyRulesUrlCategories, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := AccessControlPolicyRulesUrlCategories{}
+					if value := res.Get("category.id"); value.Exists() {
+						data.Id = types.StringValue(value.String())
 					} else {
-						cItem.Id = types.StringNull()
+						data.Id = types.StringNull()
 					}
-					if ccValue := cv.Get("reputation"); ccValue.Exists() {
-						cItem.Reputation = types.StringValue(ccValue.String())
+					if value := res.Get("reputation"); value.Exists() {
+						data.Reputation = types.StringValue(value.String())
 					} else {
-						cItem.Reputation = types.StringNull()
+						data.Reputation = types.StringNull()
 					}
-					item.UrlCategories = append(item.UrlCategories, cItem)
+					(*parent).UrlCategories = append((*parent).UrlCategories, data)
 					return true
 				})
 			}
-			if cValue := v.Get("logBegin"); cValue.Exists() {
-				item.LogBegin = types.BoolValue(cValue.Bool())
+			if value := res.Get("logBegin"); value.Exists() {
+				data.LogBegin = types.BoolValue(value.Bool())
 			} else {
-				item.LogBegin = types.BoolValue(false)
+				data.LogBegin = types.BoolValue(false)
 			}
-			if cValue := v.Get("logEnd"); cValue.Exists() {
-				item.LogEnd = types.BoolValue(cValue.Bool())
+			if value := res.Get("logEnd"); value.Exists() {
+				data.LogEnd = types.BoolValue(value.Bool())
 			} else {
-				item.LogEnd = types.BoolValue(false)
+				data.LogEnd = types.BoolValue(false)
 			}
-			if cValue := v.Get("logFiles"); cValue.Exists() {
-				item.LogFiles = types.BoolValue(cValue.Bool())
+			if value := res.Get("logFiles"); value.Exists() {
+				data.LogFiles = types.BoolValue(value.Bool())
 			} else {
-				item.LogFiles = types.BoolValue(false)
+				data.LogFiles = types.BoolValue(false)
 			}
-			if cValue := v.Get("sendEventsToFMC"); cValue.Exists() {
-				item.SendEventsToFmc = types.BoolValue(cValue.Bool())
+			if value := res.Get("sendEventsToFMC"); value.Exists() {
+				data.SendEventsToFmc = types.BoolValue(value.Bool())
 			} else {
-				item.SendEventsToFmc = types.BoolValue(false)
+				data.SendEventsToFmc = types.BoolValue(false)
 			}
-			if cValue := v.Get("enableSyslog"); cValue.Exists() {
-				item.SendSyslog = types.BoolValue(cValue.Bool())
+			if value := res.Get("enableSyslog"); value.Exists() {
+				data.SendSyslog = types.BoolValue(value.Bool())
 			} else {
-				item.SendSyslog = types.BoolValue(false)
+				data.SendSyslog = types.BoolValue(false)
 			}
-			if cValue := v.Get("syslogConfig.id"); cValue.Exists() {
-				item.SyslogConfigId = types.StringValue(cValue.String())
+			if value := res.Get("syslogConfig.id"); value.Exists() {
+				data.SyslogConfigId = types.StringValue(value.String())
 			} else {
-				item.SyslogConfigId = types.StringNull()
+				data.SyslogConfigId = types.StringNull()
 			}
-			if cValue := v.Get("syslogSeverity"); cValue.Exists() {
-				item.SyslogSeverity = types.StringValue(cValue.String())
+			if value := res.Get("syslogSeverity"); value.Exists() {
+				data.SyslogSeverity = types.StringValue(value.String())
 			} else {
-				item.SyslogSeverity = types.StringNull()
+				data.SyslogSeverity = types.StringNull()
 			}
-			if cValue := v.Get("snmpConfig.id"); cValue.Exists() {
-				item.SnmpConfigId = types.StringValue(cValue.String())
+			if value := res.Get("snmpConfig.id"); value.Exists() {
+				data.SnmpConfigId = types.StringValue(value.String())
 			} else {
-				item.SnmpConfigId = types.StringNull()
+				data.SnmpConfigId = types.StringNull()
 			}
-			if cValue := v.Get("filePolicy.id"); cValue.Exists() {
-				item.FilePolicyId = types.StringValue(cValue.String())
+			if value := res.Get("filePolicy.id"); value.Exists() {
+				data.FilePolicyId = types.StringValue(value.String())
 			} else {
-				item.FilePolicyId = types.StringNull()
+				data.FilePolicyId = types.StringNull()
 			}
-			if cValue := v.Get("ipsPolicy.id"); cValue.Exists() {
-				item.IntrusionPolicyId = types.StringValue(cValue.String())
+			if value := res.Get("ipsPolicy.id"); value.Exists() {
+				data.IntrusionPolicyId = types.StringValue(value.String())
 			} else {
-				item.IntrusionPolicyId = types.StringNull()
+				data.IntrusionPolicyId = types.StringNull()
 			}
-			data.Rules = append(data.Rules, item)
+			(*parent).Rules = append((*parent).Rules, data)
 			return true
 		})
 	}
@@ -928,17 +944,21 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 		}
 	}
 	for i := range data.Categories {
-		r := res.Get(fmt.Sprintf("dummy_categories.%d", i))
-		if value := r.Get("id"); value.Exists() && !data.Categories[i].Id.IsNull() {
-			data.Categories[i].Id = types.StringValue(value.String())
+		parent := &data
+		data := (*parent).Categories[i]
+		parentRes := &res
+		res := parentRes.Get(fmt.Sprintf("dummy_categories.%d", i))
+		if value := res.Get("id"); value.Exists() {
+			data.Id = types.StringValue(value.String())
 		} else {
-			data.Categories[i].Id = types.StringNull()
+			data.Id = types.StringNull()
 		}
-		if value := r.Get("name"); value.Exists() && !data.Categories[i].Name.IsNull() {
-			data.Categories[i].Name = types.StringValue(value.String())
+		if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
+			data.Name = types.StringValue(value.String())
 		} else {
-			data.Categories[i].Name = types.StringNull()
+			data.Name = types.StringNull()
 		}
+		(*parent).Categories[i] = data
 	}
 	{
 		l := len(res.Get("dummy_rules").Array())
@@ -951,43 +971,50 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 		}
 	}
 	for i := range data.Rules {
-		r := res.Get(fmt.Sprintf("dummy_rules.%d", i))
-		if value := r.Get("id"); value.Exists() && !data.Rules[i].Id.IsNull() {
-			data.Rules[i].Id = types.StringValue(value.String())
+		parent := &data
+		data := (*parent).Rules[i]
+		parentRes := &res
+		res := parentRes.Get(fmt.Sprintf("dummy_rules.%d", i))
+		if value := res.Get("id"); value.Exists() {
+			data.Id = types.StringValue(value.String())
 		} else {
-			data.Rules[i].Id = types.StringNull()
+			data.Id = types.StringNull()
 		}
-		if value := r.Get("action"); value.Exists() && !data.Rules[i].Action.IsNull() {
-			data.Rules[i].Action = types.StringValue(value.String())
+		if value := res.Get("action"); value.Exists() && !data.Action.IsNull() {
+			data.Action = types.StringValue(value.String())
 		} else {
-			data.Rules[i].Action = types.StringNull()
+			data.Action = types.StringNull()
 		}
-		if value := r.Get("name"); value.Exists() && !data.Rules[i].Name.IsNull() {
-			data.Rules[i].Name = types.StringValue(value.String())
+		if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
+			data.Name = types.StringValue(value.String())
 		} else {
-			data.Rules[i].Name = types.StringNull()
+			data.Name = types.StringNull()
 		}
-		if value := r.Get("metadata.category"); value.Exists() && !data.Rules[i].CategoryName.IsNull() {
-			data.Rules[i].CategoryName = types.StringValue(value.String())
+		if value := res.Get("metadata.category"); value.Exists() && !data.CategoryName.IsNull() {
+			data.CategoryName = types.StringValue(value.String())
 		} else {
-			data.Rules[i].CategoryName = types.StringNull()
+			data.CategoryName = types.StringNull()
 		}
-		if value := r.Get("metadata.section"); value.Exists() && !data.Rules[i].Section.IsNull() {
-			data.Rules[i].Section = types.StringValue(value.String())
+		if value := res.Get("metadata.section"); value.Exists() && !data.Section.IsNull() {
+			data.Section = types.StringValue(value.String())
 		} else {
-			data.Rules[i].Section = types.StringNull()
+			data.Section = types.StringNull()
 		}
-		if value := r.Get("enabled"); value.Exists() && !data.Rules[i].Enabled.IsNull() {
-			data.Rules[i].Enabled = types.BoolValue(value.Bool())
-		} else if data.Rules[i].Enabled.ValueBool() != true {
-			data.Rules[i].Enabled = types.BoolNull()
+		if value := res.Get("enabled"); value.Exists() && !data.Enabled.IsNull() {
+			data.Enabled = types.BoolValue(value.Bool())
+		} else if data.Enabled.ValueBool() != true {
+			data.Enabled = types.BoolNull()
 		}
-		for ci := 0; ci < len(data.Rules[i].SourceNetworkLiterals); ci++ {
+		for i := 0; i < len(data.SourceNetworkLiterals); i++ {
 			keys := [...]string{"value"}
-			keyValues := [...]string{data.Rules[i].SourceNetworkLiterals[ci].Value.ValueString()}
+			keyValues := [...]string{data.SourceNetworkLiterals[i].Value.ValueString()}
 
-			var cr gjson.Result
-			r.Get("sourceNetworks.literals").ForEach(
+			parent := &data
+			data := (*parent).SourceNetworkLiterals[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("sourceNetworks.literals").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -998,34 +1025,39 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].SourceNetworkLiterals[%d] = %+v",
-					ci,
-					data.Rules[i].SourceNetworkLiterals[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing SourceNetworkLiterals[%d] = %+v",
+					i,
+					(*parent).SourceNetworkLiterals[i],
 				))
-				data.Rules[i].SourceNetworkLiterals = slices.Delete(data.Rules[i].SourceNetworkLiterals, ci, ci+1)
-				ci--
+				(*parent).SourceNetworkLiterals = slices.Delete((*parent).SourceNetworkLiterals, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("value"); value.Exists() && !data.Rules[i].SourceNetworkLiterals[ci].Value.IsNull() {
-				data.Rules[i].SourceNetworkLiterals[ci].Value = types.StringValue(value.String())
+			if value := res.Get("value"); value.Exists() && !data.Value.IsNull() {
+				data.Value = types.StringValue(value.String())
 			} else {
-				data.Rules[i].SourceNetworkLiterals[ci].Value = types.StringNull()
+				data.Value = types.StringNull()
 			}
+			(*parent).SourceNetworkLiterals[i] = data
 		}
-		for ci := 0; ci < len(data.Rules[i].DestinationNetworkLiterals); ci++ {
+		for i := 0; i < len(data.DestinationNetworkLiterals); i++ {
 			keys := [...]string{"value"}
-			keyValues := [...]string{data.Rules[i].DestinationNetworkLiterals[ci].Value.ValueString()}
+			keyValues := [...]string{data.DestinationNetworkLiterals[i].Value.ValueString()}
 
-			var cr gjson.Result
-			r.Get("destinationNetworks.literals").ForEach(
+			parent := &data
+			data := (*parent).DestinationNetworkLiterals[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("destinationNetworks.literals").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -1036,34 +1068,39 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].DestinationNetworkLiterals[%d] = %+v",
-					ci,
-					data.Rules[i].DestinationNetworkLiterals[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing DestinationNetworkLiterals[%d] = %+v",
+					i,
+					(*parent).DestinationNetworkLiterals[i],
 				))
-				data.Rules[i].DestinationNetworkLiterals = slices.Delete(data.Rules[i].DestinationNetworkLiterals, ci, ci+1)
-				ci--
+				(*parent).DestinationNetworkLiterals = slices.Delete((*parent).DestinationNetworkLiterals, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("value"); value.Exists() && !data.Rules[i].DestinationNetworkLiterals[ci].Value.IsNull() {
-				data.Rules[i].DestinationNetworkLiterals[ci].Value = types.StringValue(value.String())
+			if value := res.Get("value"); value.Exists() && !data.Value.IsNull() {
+				data.Value = types.StringValue(value.String())
 			} else {
-				data.Rules[i].DestinationNetworkLiterals[ci].Value = types.StringNull()
+				data.Value = types.StringNull()
 			}
+			(*parent).DestinationNetworkLiterals[i] = data
 		}
-		for ci := 0; ci < len(data.Rules[i].SourceNetworkObjects); ci++ {
+		for i := 0; i < len(data.SourceNetworkObjects); i++ {
 			keys := [...]string{"id"}
-			keyValues := [...]string{data.Rules[i].SourceNetworkObjects[ci].Id.ValueString()}
+			keyValues := [...]string{data.SourceNetworkObjects[i].Id.ValueString()}
 
-			var cr gjson.Result
-			r.Get("sourceNetworks.objects").ForEach(
+			parent := &data
+			data := (*parent).SourceNetworkObjects[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("sourceNetworks.objects").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -1074,39 +1111,44 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].SourceNetworkObjects[%d] = %+v",
-					ci,
-					data.Rules[i].SourceNetworkObjects[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing SourceNetworkObjects[%d] = %+v",
+					i,
+					(*parent).SourceNetworkObjects[i],
 				))
-				data.Rules[i].SourceNetworkObjects = slices.Delete(data.Rules[i].SourceNetworkObjects, ci, ci+1)
-				ci--
+				(*parent).SourceNetworkObjects = slices.Delete((*parent).SourceNetworkObjects, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("id"); value.Exists() && !data.Rules[i].SourceNetworkObjects[ci].Id.IsNull() {
-				data.Rules[i].SourceNetworkObjects[ci].Id = types.StringValue(value.String())
+			if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				data.Rules[i].SourceNetworkObjects[ci].Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
-			if value := cr.Get("type"); value.Exists() && !data.Rules[i].SourceNetworkObjects[ci].Type.IsNull() {
-				data.Rules[i].SourceNetworkObjects[ci].Type = types.StringValue(value.String())
+			if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+				data.Type = types.StringValue(value.String())
 			} else {
-				data.Rules[i].SourceNetworkObjects[ci].Type = types.StringNull()
+				data.Type = types.StringNull()
 			}
+			(*parent).SourceNetworkObjects[i] = data
 		}
-		for ci := 0; ci < len(data.Rules[i].DestinationNetworkObjects); ci++ {
+		for i := 0; i < len(data.DestinationNetworkObjects); i++ {
 			keys := [...]string{"id"}
-			keyValues := [...]string{data.Rules[i].DestinationNetworkObjects[ci].Id.ValueString()}
+			keyValues := [...]string{data.DestinationNetworkObjects[i].Id.ValueString()}
 
-			var cr gjson.Result
-			r.Get("destinationNetworks.objects").ForEach(
+			parent := &data
+			data := (*parent).DestinationNetworkObjects[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("destinationNetworks.objects").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -1117,39 +1159,44 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].DestinationNetworkObjects[%d] = %+v",
-					ci,
-					data.Rules[i].DestinationNetworkObjects[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing DestinationNetworkObjects[%d] = %+v",
+					i,
+					(*parent).DestinationNetworkObjects[i],
 				))
-				data.Rules[i].DestinationNetworkObjects = slices.Delete(data.Rules[i].DestinationNetworkObjects, ci, ci+1)
-				ci--
+				(*parent).DestinationNetworkObjects = slices.Delete((*parent).DestinationNetworkObjects, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("id"); value.Exists() && !data.Rules[i].DestinationNetworkObjects[ci].Id.IsNull() {
-				data.Rules[i].DestinationNetworkObjects[ci].Id = types.StringValue(value.String())
+			if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				data.Rules[i].DestinationNetworkObjects[ci].Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
-			if value := cr.Get("type"); value.Exists() && !data.Rules[i].DestinationNetworkObjects[ci].Type.IsNull() {
-				data.Rules[i].DestinationNetworkObjects[ci].Type = types.StringValue(value.String())
+			if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+				data.Type = types.StringValue(value.String())
 			} else {
-				data.Rules[i].DestinationNetworkObjects[ci].Type = types.StringNull()
+				data.Type = types.StringNull()
 			}
+			(*parent).DestinationNetworkObjects[i] = data
 		}
-		for ci := 0; ci < len(data.Rules[i].SourceDynamicObjects); ci++ {
+		for i := 0; i < len(data.SourceDynamicObjects); i++ {
 			keys := [...]string{"id"}
-			keyValues := [...]string{data.Rules[i].SourceDynamicObjects[ci].Id.ValueString()}
+			keyValues := [...]string{data.SourceDynamicObjects[i].Id.ValueString()}
 
-			var cr gjson.Result
-			r.Get("sourceDynamicObjects.objects").ForEach(
+			parent := &data
+			data := (*parent).SourceDynamicObjects[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("sourceDynamicObjects.objects").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -1160,34 +1207,39 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].SourceDynamicObjects[%d] = %+v",
-					ci,
-					data.Rules[i].SourceDynamicObjects[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing SourceDynamicObjects[%d] = %+v",
+					i,
+					(*parent).SourceDynamicObjects[i],
 				))
-				data.Rules[i].SourceDynamicObjects = slices.Delete(data.Rules[i].SourceDynamicObjects, ci, ci+1)
-				ci--
+				(*parent).SourceDynamicObjects = slices.Delete((*parent).SourceDynamicObjects, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("id"); value.Exists() && !data.Rules[i].SourceDynamicObjects[ci].Id.IsNull() {
-				data.Rules[i].SourceDynamicObjects[ci].Id = types.StringValue(value.String())
+			if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				data.Rules[i].SourceDynamicObjects[ci].Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
+			(*parent).SourceDynamicObjects[i] = data
 		}
-		for ci := 0; ci < len(data.Rules[i].DestinationDynamicObjects); ci++ {
+		for i := 0; i < len(data.DestinationDynamicObjects); i++ {
 			keys := [...]string{"id"}
-			keyValues := [...]string{data.Rules[i].DestinationDynamicObjects[ci].Id.ValueString()}
+			keyValues := [...]string{data.DestinationDynamicObjects[i].Id.ValueString()}
 
-			var cr gjson.Result
-			r.Get("destinationDynamicObjects.objects").ForEach(
+			parent := &data
+			data := (*parent).DestinationDynamicObjects[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("destinationDynamicObjects.objects").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -1198,34 +1250,39 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].DestinationDynamicObjects[%d] = %+v",
-					ci,
-					data.Rules[i].DestinationDynamicObjects[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing DestinationDynamicObjects[%d] = %+v",
+					i,
+					(*parent).DestinationDynamicObjects[i],
 				))
-				data.Rules[i].DestinationDynamicObjects = slices.Delete(data.Rules[i].DestinationDynamicObjects, ci, ci+1)
-				ci--
+				(*parent).DestinationDynamicObjects = slices.Delete((*parent).DestinationDynamicObjects, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("id"); value.Exists() && !data.Rules[i].DestinationDynamicObjects[ci].Id.IsNull() {
-				data.Rules[i].DestinationDynamicObjects[ci].Id = types.StringValue(value.String())
+			if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				data.Rules[i].DestinationDynamicObjects[ci].Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
+			(*parent).DestinationDynamicObjects[i] = data
 		}
-		for ci := 0; ci < len(data.Rules[i].SourcePortObjects); ci++ {
+		for i := 0; i < len(data.SourcePortObjects); i++ {
 			keys := [...]string{"id"}
-			keyValues := [...]string{data.Rules[i].SourcePortObjects[ci].Id.ValueString()}
+			keyValues := [...]string{data.SourcePortObjects[i].Id.ValueString()}
 
-			var cr gjson.Result
-			r.Get("sourcePorts.objects").ForEach(
+			parent := &data
+			data := (*parent).SourcePortObjects[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("sourcePorts.objects").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -1236,34 +1293,39 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].SourcePortObjects[%d] = %+v",
-					ci,
-					data.Rules[i].SourcePortObjects[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing SourcePortObjects[%d] = %+v",
+					i,
+					(*parent).SourcePortObjects[i],
 				))
-				data.Rules[i].SourcePortObjects = slices.Delete(data.Rules[i].SourcePortObjects, ci, ci+1)
-				ci--
+				(*parent).SourcePortObjects = slices.Delete((*parent).SourcePortObjects, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("id"); value.Exists() && !data.Rules[i].SourcePortObjects[ci].Id.IsNull() {
-				data.Rules[i].SourcePortObjects[ci].Id = types.StringValue(value.String())
+			if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				data.Rules[i].SourcePortObjects[ci].Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
+			(*parent).SourcePortObjects[i] = data
 		}
-		for ci := 0; ci < len(data.Rules[i].DestinationPortObjects); ci++ {
+		for i := 0; i < len(data.DestinationPortObjects); i++ {
 			keys := [...]string{"id"}
-			keyValues := [...]string{data.Rules[i].DestinationPortObjects[ci].Id.ValueString()}
+			keyValues := [...]string{data.DestinationPortObjects[i].Id.ValueString()}
 
-			var cr gjson.Result
-			r.Get("destinationPorts.objects").ForEach(
+			parent := &data
+			data := (*parent).DestinationPortObjects[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("destinationPorts.objects").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -1274,34 +1336,39 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].DestinationPortObjects[%d] = %+v",
-					ci,
-					data.Rules[i].DestinationPortObjects[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing DestinationPortObjects[%d] = %+v",
+					i,
+					(*parent).DestinationPortObjects[i],
 				))
-				data.Rules[i].DestinationPortObjects = slices.Delete(data.Rules[i].DestinationPortObjects, ci, ci+1)
-				ci--
+				(*parent).DestinationPortObjects = slices.Delete((*parent).DestinationPortObjects, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("id"); value.Exists() && !data.Rules[i].DestinationPortObjects[ci].Id.IsNull() {
-				data.Rules[i].DestinationPortObjects[ci].Id = types.StringValue(value.String())
+			if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				data.Rules[i].DestinationPortObjects[ci].Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
+			(*parent).DestinationPortObjects[i] = data
 		}
-		for ci := 0; ci < len(data.Rules[i].SourceSecurityGroupTagObjects); ci++ {
+		for i := 0; i < len(data.SourceSecurityGroupTagObjects); i++ {
 			keys := [...]string{"id"}
-			keyValues := [...]string{data.Rules[i].SourceSecurityGroupTagObjects[ci].Id.ValueString()}
+			keyValues := [...]string{data.SourceSecurityGroupTagObjects[i].Id.ValueString()}
 
-			var cr gjson.Result
-			r.Get("sourceSecurityGroupTags.objects").ForEach(
+			parent := &data
+			data := (*parent).SourceSecurityGroupTagObjects[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("sourceSecurityGroupTags.objects").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -1312,39 +1379,44 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].SourceSecurityGroupTagObjects[%d] = %+v",
-					ci,
-					data.Rules[i].SourceSecurityGroupTagObjects[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing SourceSecurityGroupTagObjects[%d] = %+v",
+					i,
+					(*parent).SourceSecurityGroupTagObjects[i],
 				))
-				data.Rules[i].SourceSecurityGroupTagObjects = slices.Delete(data.Rules[i].SourceSecurityGroupTagObjects, ci, ci+1)
-				ci--
+				(*parent).SourceSecurityGroupTagObjects = slices.Delete((*parent).SourceSecurityGroupTagObjects, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("id"); value.Exists() && !data.Rules[i].SourceSecurityGroupTagObjects[ci].Id.IsNull() {
-				data.Rules[i].SourceSecurityGroupTagObjects[ci].Id = types.StringValue(value.String())
+			if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				data.Rules[i].SourceSecurityGroupTagObjects[ci].Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
-			if value := cr.Get("type"); value.Exists() && !data.Rules[i].SourceSecurityGroupTagObjects[ci].Type.IsNull() {
-				data.Rules[i].SourceSecurityGroupTagObjects[ci].Type = types.StringValue(value.String())
+			if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+				data.Type = types.StringValue(value.String())
 			} else {
-				data.Rules[i].SourceSecurityGroupTagObjects[ci].Type = types.StringNull()
+				data.Type = types.StringNull()
 			}
+			(*parent).SourceSecurityGroupTagObjects[i] = data
 		}
-		for ci := 0; ci < len(data.Rules[i].DestinationSecurityGroupTagObjects); ci++ {
+		for i := 0; i < len(data.DestinationSecurityGroupTagObjects); i++ {
 			keys := [...]string{"id"}
-			keyValues := [...]string{data.Rules[i].DestinationSecurityGroupTagObjects[ci].Id.ValueString()}
+			keyValues := [...]string{data.DestinationSecurityGroupTagObjects[i].Id.ValueString()}
 
-			var cr gjson.Result
-			r.Get("destinationSecurityGroupTags.objects").ForEach(
+			parent := &data
+			data := (*parent).DestinationSecurityGroupTagObjects[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("destinationSecurityGroupTags.objects").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -1355,39 +1427,44 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].DestinationSecurityGroupTagObjects[%d] = %+v",
-					ci,
-					data.Rules[i].DestinationSecurityGroupTagObjects[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing DestinationSecurityGroupTagObjects[%d] = %+v",
+					i,
+					(*parent).DestinationSecurityGroupTagObjects[i],
 				))
-				data.Rules[i].DestinationSecurityGroupTagObjects = slices.Delete(data.Rules[i].DestinationSecurityGroupTagObjects, ci, ci+1)
-				ci--
+				(*parent).DestinationSecurityGroupTagObjects = slices.Delete((*parent).DestinationSecurityGroupTagObjects, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("id"); value.Exists() && !data.Rules[i].DestinationSecurityGroupTagObjects[ci].Id.IsNull() {
-				data.Rules[i].DestinationSecurityGroupTagObjects[ci].Id = types.StringValue(value.String())
+			if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				data.Rules[i].DestinationSecurityGroupTagObjects[ci].Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
-			if value := cr.Get("type"); value.Exists() && !data.Rules[i].DestinationSecurityGroupTagObjects[ci].Type.IsNull() {
-				data.Rules[i].DestinationSecurityGroupTagObjects[ci].Type = types.StringValue(value.String())
+			if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+				data.Type = types.StringValue(value.String())
 			} else {
-				data.Rules[i].DestinationSecurityGroupTagObjects[ci].Type = types.StringNull()
+				data.Type = types.StringNull()
 			}
+			(*parent).DestinationSecurityGroupTagObjects[i] = data
 		}
-		for ci := 0; ci < len(data.Rules[i].SourceZones); ci++ {
+		for i := 0; i < len(data.SourceZones); i++ {
 			keys := [...]string{"id"}
-			keyValues := [...]string{data.Rules[i].SourceZones[ci].Id.ValueString()}
+			keyValues := [...]string{data.SourceZones[i].Id.ValueString()}
 
-			var cr gjson.Result
-			r.Get("sourceZones.objects").ForEach(
+			parent := &data
+			data := (*parent).SourceZones[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("sourceZones.objects").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -1398,34 +1475,39 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].SourceZones[%d] = %+v",
-					ci,
-					data.Rules[i].SourceZones[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing SourceZones[%d] = %+v",
+					i,
+					(*parent).SourceZones[i],
 				))
-				data.Rules[i].SourceZones = slices.Delete(data.Rules[i].SourceZones, ci, ci+1)
-				ci--
+				(*parent).SourceZones = slices.Delete((*parent).SourceZones, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("id"); value.Exists() && !data.Rules[i].SourceZones[ci].Id.IsNull() {
-				data.Rules[i].SourceZones[ci].Id = types.StringValue(value.String())
+			if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				data.Rules[i].SourceZones[ci].Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
+			(*parent).SourceZones[i] = data
 		}
-		for ci := 0; ci < len(data.Rules[i].DestinationZones); ci++ {
+		for i := 0; i < len(data.DestinationZones); i++ {
 			keys := [...]string{"id"}
-			keyValues := [...]string{data.Rules[i].DestinationZones[ci].Id.ValueString()}
+			keyValues := [...]string{data.DestinationZones[i].Id.ValueString()}
 
-			var cr gjson.Result
-			r.Get("destinationZones.objects").ForEach(
+			parent := &data
+			data := (*parent).DestinationZones[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("destinationZones.objects").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -1436,34 +1518,39 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].DestinationZones[%d] = %+v",
-					ci,
-					data.Rules[i].DestinationZones[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing DestinationZones[%d] = %+v",
+					i,
+					(*parent).DestinationZones[i],
 				))
-				data.Rules[i].DestinationZones = slices.Delete(data.Rules[i].DestinationZones, ci, ci+1)
-				ci--
+				(*parent).DestinationZones = slices.Delete((*parent).DestinationZones, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("id"); value.Exists() && !data.Rules[i].DestinationZones[ci].Id.IsNull() {
-				data.Rules[i].DestinationZones[ci].Id = types.StringValue(value.String())
+			if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				data.Rules[i].DestinationZones[ci].Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
+			(*parent).DestinationZones[i] = data
 		}
-		for ci := 0; ci < len(data.Rules[i].UrlObjects); ci++ {
+		for i := 0; i < len(data.UrlObjects); i++ {
 			keys := [...]string{"id"}
-			keyValues := [...]string{data.Rules[i].UrlObjects[ci].Id.ValueString()}
+			keyValues := [...]string{data.UrlObjects[i].Id.ValueString()}
 
-			var cr gjson.Result
-			r.Get("urls.objects").ForEach(
+			parent := &data
+			data := (*parent).UrlObjects[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("urls.objects").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -1474,34 +1561,39 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].UrlObjects[%d] = %+v",
-					ci,
-					data.Rules[i].UrlObjects[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing UrlObjects[%d] = %+v",
+					i,
+					(*parent).UrlObjects[i],
 				))
-				data.Rules[i].UrlObjects = slices.Delete(data.Rules[i].UrlObjects, ci, ci+1)
-				ci--
+				(*parent).UrlObjects = slices.Delete((*parent).UrlObjects, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("id"); value.Exists() && !data.Rules[i].UrlObjects[ci].Id.IsNull() {
-				data.Rules[i].UrlObjects[ci].Id = types.StringValue(value.String())
+			if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				data.Rules[i].UrlObjects[ci].Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
+			(*parent).UrlObjects[i] = data
 		}
-		for ci := 0; ci < len(data.Rules[i].UrlCategories); ci++ {
+		for i := 0; i < len(data.UrlCategories); i++ {
 			keys := [...]string{"category.id"}
-			keyValues := [...]string{data.Rules[i].UrlCategories[ci].Id.ValueString()}
+			keyValues := [...]string{data.UrlCategories[i].Id.ValueString()}
 
-			var cr gjson.Result
-			r.Get("urls.urlCategoriesWithReputation").ForEach(
+			parent := &data
+			data := (*parent).UrlCategories[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("urls.urlCategoriesWithReputation").ForEach(
 				func(_, v gjson.Result) bool {
 					found := false
 					for ik := range keys {
@@ -1512,83 +1604,85 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 						found = true
 					}
 					if found {
-						cr = v
+						res = v
 						return false
 					}
 					return true
 				},
 			)
-			if !cr.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing data.Rules[i].UrlCategories[%d] = %+v",
-					ci,
-					data.Rules[i].UrlCategories[ci],
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing UrlCategories[%d] = %+v",
+					i,
+					(*parent).UrlCategories[i],
 				))
-				data.Rules[i].UrlCategories = slices.Delete(data.Rules[i].UrlCategories, ci, ci+1)
-				ci--
+				(*parent).UrlCategories = slices.Delete((*parent).UrlCategories, i, i+1)
+				i--
 
 				continue
 			}
-			if value := cr.Get("category.id"); value.Exists() && !data.Rules[i].UrlCategories[ci].Id.IsNull() {
-				data.Rules[i].UrlCategories[ci].Id = types.StringValue(value.String())
+			if value := res.Get("category.id"); value.Exists() && !data.Id.IsNull() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				data.Rules[i].UrlCategories[ci].Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
-			if value := cr.Get("reputation"); value.Exists() && !data.Rules[i].UrlCategories[ci].Reputation.IsNull() {
-				data.Rules[i].UrlCategories[ci].Reputation = types.StringValue(value.String())
+			if value := res.Get("reputation"); value.Exists() && !data.Reputation.IsNull() {
+				data.Reputation = types.StringValue(value.String())
 			} else {
-				data.Rules[i].UrlCategories[ci].Reputation = types.StringNull()
+				data.Reputation = types.StringNull()
 			}
+			(*parent).UrlCategories[i] = data
 		}
-		if value := r.Get("logBegin"); value.Exists() && !data.Rules[i].LogBegin.IsNull() {
-			data.Rules[i].LogBegin = types.BoolValue(value.Bool())
-		} else if data.Rules[i].LogBegin.ValueBool() != false {
-			data.Rules[i].LogBegin = types.BoolNull()
+		if value := res.Get("logBegin"); value.Exists() && !data.LogBegin.IsNull() {
+			data.LogBegin = types.BoolValue(value.Bool())
+		} else if data.LogBegin.ValueBool() != false {
+			data.LogBegin = types.BoolNull()
 		}
-		if value := r.Get("logEnd"); value.Exists() && !data.Rules[i].LogEnd.IsNull() {
-			data.Rules[i].LogEnd = types.BoolValue(value.Bool())
-		} else if data.Rules[i].LogEnd.ValueBool() != false {
-			data.Rules[i].LogEnd = types.BoolNull()
+		if value := res.Get("logEnd"); value.Exists() && !data.LogEnd.IsNull() {
+			data.LogEnd = types.BoolValue(value.Bool())
+		} else if data.LogEnd.ValueBool() != false {
+			data.LogEnd = types.BoolNull()
 		}
-		if value := r.Get("logFiles"); value.Exists() && !data.Rules[i].LogFiles.IsNull() {
-			data.Rules[i].LogFiles = types.BoolValue(value.Bool())
-		} else if data.Rules[i].LogFiles.ValueBool() != false {
-			data.Rules[i].LogFiles = types.BoolNull()
+		if value := res.Get("logFiles"); value.Exists() && !data.LogFiles.IsNull() {
+			data.LogFiles = types.BoolValue(value.Bool())
+		} else if data.LogFiles.ValueBool() != false {
+			data.LogFiles = types.BoolNull()
 		}
-		if value := r.Get("sendEventsToFMC"); value.Exists() && !data.Rules[i].SendEventsToFmc.IsNull() {
-			data.Rules[i].SendEventsToFmc = types.BoolValue(value.Bool())
-		} else if data.Rules[i].SendEventsToFmc.ValueBool() != false {
-			data.Rules[i].SendEventsToFmc = types.BoolNull()
+		if value := res.Get("sendEventsToFMC"); value.Exists() && !data.SendEventsToFmc.IsNull() {
+			data.SendEventsToFmc = types.BoolValue(value.Bool())
+		} else if data.SendEventsToFmc.ValueBool() != false {
+			data.SendEventsToFmc = types.BoolNull()
 		}
-		if value := r.Get("enableSyslog"); value.Exists() && !data.Rules[i].SendSyslog.IsNull() {
-			data.Rules[i].SendSyslog = types.BoolValue(value.Bool())
-		} else if data.Rules[i].SendSyslog.ValueBool() != false {
-			data.Rules[i].SendSyslog = types.BoolNull()
+		if value := res.Get("enableSyslog"); value.Exists() && !data.SendSyslog.IsNull() {
+			data.SendSyslog = types.BoolValue(value.Bool())
+		} else if data.SendSyslog.ValueBool() != false {
+			data.SendSyslog = types.BoolNull()
 		}
-		if value := r.Get("syslogConfig.id"); value.Exists() && !data.Rules[i].SyslogConfigId.IsNull() {
-			data.Rules[i].SyslogConfigId = types.StringValue(value.String())
+		if value := res.Get("syslogConfig.id"); value.Exists() && !data.SyslogConfigId.IsNull() {
+			data.SyslogConfigId = types.StringValue(value.String())
 		} else {
-			data.Rules[i].SyslogConfigId = types.StringNull()
+			data.SyslogConfigId = types.StringNull()
 		}
-		if value := r.Get("syslogSeverity"); value.Exists() && !data.Rules[i].SyslogSeverity.IsNull() {
-			data.Rules[i].SyslogSeverity = types.StringValue(value.String())
+		if value := res.Get("syslogSeverity"); value.Exists() && !data.SyslogSeverity.IsNull() {
+			data.SyslogSeverity = types.StringValue(value.String())
 		} else {
-			data.Rules[i].SyslogSeverity = types.StringNull()
+			data.SyslogSeverity = types.StringNull()
 		}
-		if value := r.Get("snmpConfig.id"); value.Exists() && !data.Rules[i].SnmpConfigId.IsNull() {
-			data.Rules[i].SnmpConfigId = types.StringValue(value.String())
+		if value := res.Get("snmpConfig.id"); value.Exists() && !data.SnmpConfigId.IsNull() {
+			data.SnmpConfigId = types.StringValue(value.String())
 		} else {
-			data.Rules[i].SnmpConfigId = types.StringNull()
+			data.SnmpConfigId = types.StringNull()
 		}
-		if value := r.Get("filePolicy.id"); value.Exists() && !data.Rules[i].FilePolicyId.IsNull() {
-			data.Rules[i].FilePolicyId = types.StringValue(value.String())
+		if value := res.Get("filePolicy.id"); value.Exists() && !data.FilePolicyId.IsNull() {
+			data.FilePolicyId = types.StringValue(value.String())
 		} else {
-			data.Rules[i].FilePolicyId = types.StringNull()
+			data.FilePolicyId = types.StringNull()
 		}
-		if value := r.Get("ipsPolicy.id"); value.Exists() && !data.Rules[i].IntrusionPolicyId.IsNull() {
-			data.Rules[i].IntrusionPolicyId = types.StringValue(value.String())
+		if value := res.Get("ipsPolicy.id"); value.Exists() && !data.IntrusionPolicyId.IsNull() {
+			data.IntrusionPolicyId = types.StringValue(value.String())
 		} else {
-			data.Rules[i].IntrusionPolicyId = types.StringNull()
+			data.IntrusionPolicyId = types.StringNull()
 		}
+		(*parent).Rules[i] = data
 	}
 }
 
@@ -1632,8 +1726,7 @@ func (data *AccessControlPolicy) fromBodyUnknowns(ctx context.Context, res gjson
 	}
 	for i := range data.Categories {
 		r := res.Get(fmt.Sprintf("dummy_categories.%d", i))
-		if data.Categories[i].Id.IsUnknown() {
-			v := data.Categories[i]
+		if v := data.Categories[i]; v.Id.IsUnknown() {
 			if value := r.Get("id"); value.Exists() {
 				v.Id = types.StringValue(value.String())
 			} else {
@@ -1644,8 +1737,7 @@ func (data *AccessControlPolicy) fromBodyUnknowns(ctx context.Context, res gjson
 	}
 	for i := range data.Rules {
 		r := res.Get(fmt.Sprintf("dummy_rules.%d", i))
-		if data.Rules[i].Id.IsUnknown() {
-			v := data.Rules[i]
+		if v := data.Rules[i]; v.Id.IsUnknown() {
 			if value := r.Get("id"); value.Exists() {
 				v.Id = types.StringValue(value.String())
 			} else {

--- a/internal/provider/model_fmc_access_control_policy.go
+++ b/internal/provider/model_fmc_access_control_policy.go
@@ -230,7 +230,7 @@ func (data AccessControlPolicy) toBody(ctx context.Context, state AccessControlP
 		body, _ = sjson.Set(body, "dummy_categories", []interface{}{})
 		for _, item := range data.Categories {
 			itemBody := ""
-			if !item.Id.IsNull() {
+			if !item.Id.IsNull() && !item.Id.IsUnknown() {
 				itemBody, _ = sjson.Set(itemBody, "id", item.Id.ValueString())
 			}
 			if !item.Name.IsNull() {
@@ -246,7 +246,7 @@ func (data AccessControlPolicy) toBody(ctx context.Context, state AccessControlP
 		body, _ = sjson.Set(body, "dummy_rules", []interface{}{})
 		for _, item := range data.Rules {
 			itemBody := ""
-			if !item.Id.IsNull() {
+			if !item.Id.IsNull() && !item.Id.IsUnknown() {
 				itemBody, _ = sjson.Set(itemBody, "id", item.Id.ValueString())
 			}
 			if !item.Action.IsNull() {
@@ -1633,21 +1633,25 @@ func (data *AccessControlPolicy) fromBodyUnknowns(ctx context.Context, res gjson
 	for i := range data.Categories {
 		r := res.Get(fmt.Sprintf("dummy_categories.%d", i))
 		if data.Categories[i].Id.IsUnknown() {
+			v := data.Categories[i]
 			if value := r.Get("id"); value.Exists() {
-				data.Categories[i].Id = types.StringValue(value.String())
+				v.Id = types.StringValue(value.String())
 			} else {
-				data.Categories[i].Id = types.StringNull()
+				v.Id = types.StringNull()
 			}
+			data.Categories[i] = v
 		}
 	}
 	for i := range data.Rules {
 		r := res.Get(fmt.Sprintf("dummy_rules.%d", i))
 		if data.Rules[i].Id.IsUnknown() {
+			v := data.Rules[i]
 			if value := r.Get("id"); value.Exists() {
-				data.Rules[i].Id = types.StringValue(value.String())
+				v.Id = types.StringValue(value.String())
 			} else {
-				data.Rules[i].Id = types.StringNull()
+				v.Id = types.StringNull()
 			}
+			data.Rules[i] = v
 		}
 	}
 }

--- a/internal/provider/model_fmc_device_ipv4_static_route.go
+++ b/internal/provider/model_fmc_device_ipv4_static_route.go
@@ -111,14 +111,15 @@ func (data *DeviceIPv4StaticRoute) fromBody(ctx context.Context, res gjson.Resul
 	}
 	if value := res.Get("selectedNetworks"); value.Exists() {
 		data.DestinationNetworks = make([]DeviceIPv4StaticRouteDestinationNetworks, 0)
-		value.ForEach(func(k, v gjson.Result) bool {
-			item := DeviceIPv4StaticRouteDestinationNetworks{}
-			if cValue := v.Get("id"); cValue.Exists() {
-				item.Id = types.StringValue(cValue.String())
+		value.ForEach(func(k, res gjson.Result) bool {
+			parent := &data
+			data := DeviceIPv4StaticRouteDestinationNetworks{}
+			if value := res.Get("id"); value.Exists() {
+				data.Id = types.StringValue(value.String())
 			} else {
-				item.Id = types.StringNull()
+				data.Id = types.StringNull()
 			}
-			data.DestinationNetworks = append(data.DestinationNetworks, item)
+			(*parent).DestinationNetworks = append((*parent).DestinationNetworks, data)
 			return true
 		})
 	}
@@ -162,8 +163,12 @@ func (data *DeviceIPv4StaticRoute) fromBodyPartial(ctx context.Context, res gjso
 		keys := [...]string{"id"}
 		keyValues := [...]string{data.DestinationNetworks[i].Id.ValueString()}
 
-		var r gjson.Result
-		res.Get("selectedNetworks").ForEach(
+		parent := &data
+		data := (*parent).DestinationNetworks[i]
+		parentRes := &res
+		var res gjson.Result
+
+		parentRes.Get("selectedNetworks").ForEach(
 			func(_, v gjson.Result) bool {
 				found := false
 				for ik := range keys {
@@ -174,27 +179,28 @@ func (data *DeviceIPv4StaticRoute) fromBodyPartial(ctx context.Context, res gjso
 					found = true
 				}
 				if found {
-					r = v
+					res = v
 					return false
 				}
 				return true
 			},
 		)
-		if !r.Exists() {
-			tflog.Debug(ctx, fmt.Sprintf("removing data.DestinationNetworks[%d] = %+v",
+		if !res.Exists() {
+			tflog.Debug(ctx, fmt.Sprintf("removing DestinationNetworks[%d] = %+v",
 				i,
-				data.DestinationNetworks[i],
+				(*parent).DestinationNetworks[i],
 			))
-			data.DestinationNetworks = slices.Delete(data.DestinationNetworks, i, i+1)
+			(*parent).DestinationNetworks = slices.Delete((*parent).DestinationNetworks, i, i+1)
 			i--
 
 			continue
 		}
-		if value := r.Get("id"); value.Exists() && !data.DestinationNetworks[i].Id.IsNull() {
-			data.DestinationNetworks[i].Id = types.StringValue(value.String())
+		if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+			data.Id = types.StringValue(value.String())
 		} else {
-			data.DestinationNetworks[i].Id = types.StringNull()
+			data.Id = types.StringNull()
 		}
+		(*parent).DestinationNetworks[i] = data
 	}
 	if value := res.Get("metricValue"); value.Exists() && !data.MetricValue.IsNull() {
 		data.MetricValue = types.Int64Value(value.Int())

--- a/internal/provider/model_fmc_device_physical_interface.go
+++ b/internal/provider/model_fmc_device_physical_interface.go
@@ -263,24 +263,25 @@ func (data *DevicePhysicalInterface) fromBody(ctx context.Context, res gjson.Res
 	}
 	if value := res.Get("ipv6.addresses"); value.Exists() {
 		data.Ipv6Addresses = make([]DevicePhysicalInterfaceIpv6Addresses, 0)
-		value.ForEach(func(k, v gjson.Result) bool {
-			item := DevicePhysicalInterfaceIpv6Addresses{}
-			if cValue := v.Get("address"); cValue.Exists() {
-				item.Address = types.StringValue(cValue.String())
+		value.ForEach(func(k, res gjson.Result) bool {
+			parent := &data
+			data := DevicePhysicalInterfaceIpv6Addresses{}
+			if value := res.Get("address"); value.Exists() {
+				data.Address = types.StringValue(value.String())
 			} else {
-				item.Address = types.StringNull()
+				data.Address = types.StringNull()
 			}
-			if cValue := v.Get("prefix"); cValue.Exists() {
-				item.Prefix = types.StringValue(cValue.String())
+			if value := res.Get("prefix"); value.Exists() {
+				data.Prefix = types.StringValue(value.String())
 			} else {
-				item.Prefix = types.StringNull()
+				data.Prefix = types.StringNull()
 			}
-			if cValue := v.Get("enforceEUI64"); cValue.Exists() {
-				item.EnforceEui = types.BoolValue(cValue.Bool())
+			if value := res.Get("enforceEUI64"); value.Exists() {
+				data.EnforceEui = types.BoolValue(value.Bool())
 			} else {
-				item.EnforceEui = types.BoolNull()
+				data.EnforceEui = types.BoolNull()
 			}
-			data.Ipv6Addresses = append(data.Ipv6Addresses, item)
+			(*parent).Ipv6Addresses = append((*parent).Ipv6Addresses, data)
 			return true
 		})
 	}
@@ -394,8 +395,12 @@ func (data *DevicePhysicalInterface) fromBodyPartial(ctx context.Context, res gj
 		keys := [...]string{"address", "prefix"}
 		keyValues := [...]string{data.Ipv6Addresses[i].Address.ValueString(), data.Ipv6Addresses[i].Prefix.ValueString()}
 
-		var r gjson.Result
-		res.Get("ipv6.addresses").ForEach(
+		parent := &data
+		data := (*parent).Ipv6Addresses[i]
+		parentRes := &res
+		var res gjson.Result
+
+		parentRes.Get("ipv6.addresses").ForEach(
 			func(_, v gjson.Result) bool {
 				found := false
 				for ik := range keys {
@@ -406,37 +411,38 @@ func (data *DevicePhysicalInterface) fromBodyPartial(ctx context.Context, res gj
 					found = true
 				}
 				if found {
-					r = v
+					res = v
 					return false
 				}
 				return true
 			},
 		)
-		if !r.Exists() {
-			tflog.Debug(ctx, fmt.Sprintf("removing data.Ipv6Addresses[%d] = %+v",
+		if !res.Exists() {
+			tflog.Debug(ctx, fmt.Sprintf("removing Ipv6Addresses[%d] = %+v",
 				i,
-				data.Ipv6Addresses[i],
+				(*parent).Ipv6Addresses[i],
 			))
-			data.Ipv6Addresses = slices.Delete(data.Ipv6Addresses, i, i+1)
+			(*parent).Ipv6Addresses = slices.Delete((*parent).Ipv6Addresses, i, i+1)
 			i--
 
 			continue
 		}
-		if value := r.Get("address"); value.Exists() && !data.Ipv6Addresses[i].Address.IsNull() {
-			data.Ipv6Addresses[i].Address = types.StringValue(value.String())
+		if value := res.Get("address"); value.Exists() && !data.Address.IsNull() {
+			data.Address = types.StringValue(value.String())
 		} else {
-			data.Ipv6Addresses[i].Address = types.StringNull()
+			data.Address = types.StringNull()
 		}
-		if value := r.Get("prefix"); value.Exists() && !data.Ipv6Addresses[i].Prefix.IsNull() {
-			data.Ipv6Addresses[i].Prefix = types.StringValue(value.String())
+		if value := res.Get("prefix"); value.Exists() && !data.Prefix.IsNull() {
+			data.Prefix = types.StringValue(value.String())
 		} else {
-			data.Ipv6Addresses[i].Prefix = types.StringNull()
+			data.Prefix = types.StringNull()
 		}
-		if value := r.Get("enforceEUI64"); value.Exists() && !data.Ipv6Addresses[i].EnforceEui.IsNull() {
-			data.Ipv6Addresses[i].EnforceEui = types.BoolValue(value.Bool())
+		if value := res.Get("enforceEUI64"); value.Exists() && !data.EnforceEui.IsNull() {
+			data.EnforceEui = types.BoolValue(value.Bool())
 		} else {
-			data.Ipv6Addresses[i].EnforceEui = types.BoolNull()
+			data.EnforceEui = types.BoolNull()
 		}
+		(*parent).Ipv6Addresses[i] = data
 	}
 }
 

--- a/internal/provider/model_fmc_device_subinterface.go
+++ b/internal/provider/model_fmc_device_subinterface.go
@@ -275,24 +275,25 @@ func (data *DeviceSubinterface) fromBody(ctx context.Context, res gjson.Result) 
 	}
 	if value := res.Get("ipv6.addresses"); value.Exists() {
 		data.Ipv6Addresses = make([]DeviceSubinterfaceIpv6Addresses, 0)
-		value.ForEach(func(k, v gjson.Result) bool {
-			item := DeviceSubinterfaceIpv6Addresses{}
-			if cValue := v.Get("address"); cValue.Exists() {
-				item.Address = types.StringValue(cValue.String())
+		value.ForEach(func(k, res gjson.Result) bool {
+			parent := &data
+			data := DeviceSubinterfaceIpv6Addresses{}
+			if value := res.Get("address"); value.Exists() {
+				data.Address = types.StringValue(value.String())
 			} else {
-				item.Address = types.StringNull()
+				data.Address = types.StringNull()
 			}
-			if cValue := v.Get("prefix"); cValue.Exists() {
-				item.Prefix = types.StringValue(cValue.String())
+			if value := res.Get("prefix"); value.Exists() {
+				data.Prefix = types.StringValue(value.String())
 			} else {
-				item.Prefix = types.StringNull()
+				data.Prefix = types.StringNull()
 			}
-			if cValue := v.Get("enforceEUI64"); cValue.Exists() {
-				item.EnforceEui = types.BoolValue(cValue.Bool())
+			if value := res.Get("enforceEUI64"); value.Exists() {
+				data.EnforceEui = types.BoolValue(value.Bool())
 			} else {
-				item.EnforceEui = types.BoolNull()
+				data.EnforceEui = types.BoolNull()
 			}
-			data.Ipv6Addresses = append(data.Ipv6Addresses, item)
+			(*parent).Ipv6Addresses = append((*parent).Ipv6Addresses, data)
 			return true
 		})
 	}
@@ -411,8 +412,12 @@ func (data *DeviceSubinterface) fromBodyPartial(ctx context.Context, res gjson.R
 		keys := [...]string{"address", "prefix"}
 		keyValues := [...]string{data.Ipv6Addresses[i].Address.ValueString(), data.Ipv6Addresses[i].Prefix.ValueString()}
 
-		var r gjson.Result
-		res.Get("ipv6.addresses").ForEach(
+		parent := &data
+		data := (*parent).Ipv6Addresses[i]
+		parentRes := &res
+		var res gjson.Result
+
+		parentRes.Get("ipv6.addresses").ForEach(
 			func(_, v gjson.Result) bool {
 				found := false
 				for ik := range keys {
@@ -423,37 +428,38 @@ func (data *DeviceSubinterface) fromBodyPartial(ctx context.Context, res gjson.R
 					found = true
 				}
 				if found {
-					r = v
+					res = v
 					return false
 				}
 				return true
 			},
 		)
-		if !r.Exists() {
-			tflog.Debug(ctx, fmt.Sprintf("removing data.Ipv6Addresses[%d] = %+v",
+		if !res.Exists() {
+			tflog.Debug(ctx, fmt.Sprintf("removing Ipv6Addresses[%d] = %+v",
 				i,
-				data.Ipv6Addresses[i],
+				(*parent).Ipv6Addresses[i],
 			))
-			data.Ipv6Addresses = slices.Delete(data.Ipv6Addresses, i, i+1)
+			(*parent).Ipv6Addresses = slices.Delete((*parent).Ipv6Addresses, i, i+1)
 			i--
 
 			continue
 		}
-		if value := r.Get("address"); value.Exists() && !data.Ipv6Addresses[i].Address.IsNull() {
-			data.Ipv6Addresses[i].Address = types.StringValue(value.String())
+		if value := res.Get("address"); value.Exists() && !data.Address.IsNull() {
+			data.Address = types.StringValue(value.String())
 		} else {
-			data.Ipv6Addresses[i].Address = types.StringNull()
+			data.Address = types.StringNull()
 		}
-		if value := r.Get("prefix"); value.Exists() && !data.Ipv6Addresses[i].Prefix.IsNull() {
-			data.Ipv6Addresses[i].Prefix = types.StringValue(value.String())
+		if value := res.Get("prefix"); value.Exists() && !data.Prefix.IsNull() {
+			data.Prefix = types.StringValue(value.String())
 		} else {
-			data.Ipv6Addresses[i].Prefix = types.StringNull()
+			data.Prefix = types.StringNull()
 		}
-		if value := r.Get("enforceEUI64"); value.Exists() && !data.Ipv6Addresses[i].EnforceEui.IsNull() {
-			data.Ipv6Addresses[i].EnforceEui = types.BoolValue(value.Bool())
+		if value := res.Get("enforceEUI64"); value.Exists() && !data.EnforceEui.IsNull() {
+			data.EnforceEui = types.BoolValue(value.Bool())
 		} else {
-			data.Ipv6Addresses[i].EnforceEui = types.BoolNull()
+			data.EnforceEui = types.BoolNull()
 		}
+		(*parent).Ipv6Addresses[i] = data
 	}
 }
 


### PR DESCRIPTION
There are three goals about `gen/templates` mixed here:

1. Reduce the repeated occurrences of nearly-identical-but-not-always code. The reason is I tried to add a major functionality to templates and my progress was grinding nearly to a halt. Subjectively, I was having major problems even coherently editing `gen/templates/model.go`. The only way to proceed was to introduce subtemplates:

     - considerably reduce template code ("nested" code might be even untested/dead code: no yaml currently generates one of the levels)
     - the remaining code is more readable
     - code with subtemplates is infinitely nestable (not capped at 4 levels)

2. Add `Map` type. This goal will be better explained/shown/corrected on the `fmc_network_groups` PR, which I'm ready to show in full (branch br18 is a draft).

3. Add more yaml validation - for Map and for the existing List/Set, fail hard when user specifies nonsensical/unsupported yaml.